### PR TITLE
gem executables in bin should not reference bundler.

### DIFF
--- a/bin/pliny-generate
+++ b/bin/pliny-generate
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require "bundler"
-Bundler.require
+require "pliny"
 
 Pliny::Commands::Generator.run(ARGV.dup)

--- a/bin/pliny-new
+++ b/bin/pliny-new
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require "bundler"
-Bundler.require
+require "pliny"
 
 Pliny::Commands::Creator.run(ARGV.dup)


### PR DESCRIPTION
Gem executables should not reference bundler as that implies working in a bundled environment. That breaks when the gem has been installed via `gem install` and you're just trying to run one of the provided executables (such as `pliny-new`).
