### PR TITLE
Specially include template files as they're under a submodule.

### DIFF
--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
 
   gem.executables = %x{ git ls-files }.split("\n").select { |d| d =~ /^bin\// }.map { |d| d.gsub(/^bin\//, "") }
-  gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|template/|test/)} }
+  gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} } +
+    %x{ cd template && git ls-files }.split("\n").map {|f| File.join("template", f) }
 
   gem.add_dependency "activesupport",  "~> 4.1",  ">= 4.1.0"
   gem.add_dependency "multi_json",     "~> 1.9",  ">= 1.9.3"


### PR DESCRIPTION
`git ls-files` does not include the contents of the `template/` submodule directory. Do a bit of extra work to get them included in the gem.
