### PR TITLE
Add a db:seed tasks

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -36,8 +36,18 @@ namespace :db do
     end
   end
 
+  desc "Seed the database with data"
+  task :seed do
+    if File.exist?('./db/seeds.rb')
+      database_urls.each do |database_url|
+        Sequel.connect(database_url)
+        load 'db/seeds.rb'
+      end
+    end
+  end
+
   desc "Reset the database"
-  task :reset => [:nuke, :migrate]
+  task :reset => [:nuke, :migrate, :seed]
 
   desc "Create the database"
   task :create do


### PR DESCRIPTION
Provide a hook to write a seed data script in `db/seeds` against the databases
present.  Will not run unless the file is present and correct.

Note related template PR here:  https://github.com/interagent/pliny-template/pull/99
