### PR TITLE
Change db name on generated apps

### DIFF
--- a/lib/pliny/commands/creator.rb
+++ b/lib/pliny/commands/creator.rb
@@ -37,7 +37,10 @@ module Pliny::Commands
         db.path  = "/#{name}-#{db_env_suffix}"
         env      = File.read(env_path)
         File.open(env_path, "w") do |f|
-          f.puts env.sub(/DATABASE_URL=.*/, "DATABASE_URL=#{db}")
+          # ruby's URI#to_s renders foo:/bar when there's no host
+          # we want foo:///bar instead!
+          db_url = db.to_s.sub(":/", ":///")
+          f.puts env.sub(/DATABASE_URL=.*/, "DATABASE_URL=#{db_url}")
         end
       end
     end

--- a/test/commands/creator_test.rb
+++ b/test/commands/creator_test.rb
@@ -22,5 +22,21 @@ describe Pliny::Commands::Creator do
       @gen.run!
       refute File.exists?("./foobar/.git")
     end
+
+    it "changes DATABASE_URL in .env.sample to use the app name" do
+      @gen.run!
+      db_url = File.read("./foobar/.env.sample").split("\n").detect do |line|
+        line.include?("DATABASE_URL=")
+      end
+      assert_equal "DATABASE_URL=postgres:///foobar-development", db_url
+    end
+
+    it "changes DATABASE_URL in .env.test to use the app name" do
+      @gen.run!
+      db_url = File.read("./foobar/.env.test").split("\n").detect do |line|
+        line.include?("DATABASE_URL=")
+      end
+      assert_equal "DATABASE_URL=postgres:///foobar-test", db_url
+    end
   end
 end


### PR DESCRIPTION
Tweak `.env.sample` and `.test` so DATABASE_URL has the app name (eg: myapp-development instead of pliny-development).

Also, use the `postgres:///` syntax as @deafbybeheading awesomely noted in #2.
