### PR TITLE
Drop deleted_at from standard model migration

### DIFF
--- a/lib/pliny/templates/model_migration.erb
+++ b/lib/pliny/templates/model_migration.erb
@@ -4,7 +4,6 @@ Sequel.migration do
       uuid         :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
       timestamptz  :created_at, default: Sequel.function(:now), null: false
       timestamptz  :updated_at
-      timestamptz  :deleted_at
     end
   end
 end


### PR DESCRIPTION
this won't work until the user sets sequel-paranoia. add db bloat
on top of it and I think we should leave out for now, could just
find a way to direct users to it in the docs instead?

/cc @mfine
