### PR TITLE
Rename endpoints to resources

### DIFF
--- a/lib/pliny/commands/generator.rb
+++ b/lib/pliny/commands/generator.rb
@@ -27,10 +27,10 @@ module Pliny::Commands
       end
 
       case type
-      when "endpoint"
-        create_endpoint(scaffold: false)
-        create_endpoint_test
-        create_endpoint_acceptance_test(scaffold: false)
+      when "resource"
+        create_resource(scaffold: false)
+        create_resource_test
+        create_resource_acceptance_test(scaffold: false)
       when "mediator"
         create_mediator
         create_mediator_test
@@ -41,9 +41,9 @@ module Pliny::Commands
         create_model_migration
         create_model_test
       when "scaffold"
-        create_endpoint(scaffold: true)
-        create_endpoint_test
-        create_endpoint_acceptance_test(scaffold: true)
+        create_resource(scaffold: true)
+        create_resource_test
+        create_resource_acceptance_test(scaffold: true)
         create_model
         create_model_migration
         create_model_test
@@ -94,23 +94,23 @@ module Pliny::Commands
       stream.puts msg
     end
 
-    def create_endpoint(options = {})
-      endpoint = "./lib/endpoints/#{table_name}.rb"
-      template = options[:scaffold] ? "endpoint_scaffold.erb" : "endpoint.erb"
-      render_template(template, endpoint, {
+    def create_resource(options = {})
+      resource = "./lib/resources/#{table_name}.rb"
+      template = options[:scaffold] ? "resource_scaffold.erb" : "resource.erb"
+      render_template(template, resource, {
         plural_class_name: plural_class_name,
         singular_class_name: singular_class_name,
         field_name: field_name,
         url_path:   url_path,
       })
-      display "created endpoint file #{endpoint}"
+      display "created resource file #{resource}"
       display "add the following to lib/routes.rb:"
-      display "  mount Endpoints::#{plural_class_name}"
+      display "  mount Resources::#{plural_class_name}"
     end
 
-    def create_endpoint_test
-      test = "./spec/endpoints/#{table_name}_spec.rb"
-      render_template("endpoint_test.erb", test, {
+    def create_resource_test
+      test = "./spec/resources/#{table_name}_spec.rb"
+      render_template("resource_test.erb", test, {
         plural_class_name: plural_class_name,
         singular_class_name: singular_class_name,
         url_path:   url_path,
@@ -118,10 +118,10 @@ module Pliny::Commands
       display "created test #{test}"
     end
 
-    def create_endpoint_acceptance_test(options = {})
+    def create_resource_acceptance_test(options = {})
       test = "./spec/acceptance/#{table_name}_spec.rb"
-      template = options[:scaffold] ? "endpoint_scaffold_acceptance_test.erb" :
-        "endpoint_acceptance_test.erb"
+      template = options[:scaffold] ? "resource_scaffold_acceptance_test.erb" :
+        "resource_acceptance_test.erb"
       render_template(template, test, {
         plural_class_name: plural_class_name,
         field_name: field_name,

--- a/lib/pliny/templates/resource.erb
+++ b/lib/pliny/templates/resource.erb
@@ -1,4 +1,4 @@
-module Endpoints
+module Resources
   class <%= plural_class_name %> < Base
     namespace "<%= url_path %>" do
       before do

--- a/lib/pliny/templates/resource_acceptance_test.erb
+++ b/lib/pliny/templates/resource_acceptance_test.erb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::<%= plural_class_name %> do
+describe Resources::<%= plural_class_name %> do
   include Committee::Test::Methods
   include Rack::Test::Methods
 

--- a/lib/pliny/templates/resource_scaffold.erb
+++ b/lib/pliny/templates/resource_scaffold.erb
@@ -1,4 +1,4 @@
-module Endpoints
+module Resources
   class <%= plural_class_name %> < Base
     namespace "<%= url_path %>" do
       before do

--- a/lib/pliny/templates/resource_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/resource_scaffold_acceptance_test.erb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::<%= plural_class_name %> do
+describe Resources::<%= plural_class_name %> do
   include Committee::Test::Methods
   include Rack::Test::Methods
 

--- a/lib/pliny/templates/resource_test.erb
+++ b/lib/pliny/templates/resource_test.erb
@@ -1,10 +1,10 @@
 require "spec_helper"
 
-describe Endpoints::<%= plural_class_name %> do
+describe Resources::<%= plural_class_name %> do
   include Rack::Test::Methods
 
   def app
-    Endpoints::<%= plural_class_name %>
+    Resources::<%= plural_class_name %>
   end
 
   describe "GET <%= url_path %>" do

--- a/test/commands/generator_test.rb
+++ b/test/commands/generator_test.rb
@@ -30,7 +30,7 @@ describe Pliny::Commands::Generator do
   end
 
   describe "#singular_class_name" do
-    it "builds a class name for an endpoint" do
+    it "builds a class name in the plural" do
       @gen.args = ["model", "resource_histories"]
       assert_equal "ResourceHistory", @gen.singular_class_name
     end
@@ -65,21 +65,21 @@ describe Pliny::Commands::Generator do
       Timecop.return
     end
 
-    describe "generating endpoints" do
+    describe "generating resources" do
       before do
-        @gen.args = ["endpoint", "artists"]
+        @gen.args = ["resource", "artists"]
         @gen.run!
       end
 
-      it "creates a new endpoint module" do
-        assert File.exists?("lib/endpoints/artists.rb")
+      it "creates a new resource module" do
+        assert File.exists?("lib/resources/artists.rb")
       end
 
-      it "creates an endpoint test" do
-        assert File.exists?("spec/endpoints/artists_spec.rb")
+      it "creates an resource test" do
+        assert File.exists?("spec/resources/artists_spec.rb")
       end
 
-      it "creates an endpoint acceptance test" do
+      it "creates an resource acceptance test" do
         assert File.exists?("spec/acceptance/artists_spec.rb")
       end
     end
@@ -124,15 +124,15 @@ describe Pliny::Commands::Generator do
         @gen.run!
       end
 
-      it "creates a new endpoint module" do
-        assert File.exists?("lib/endpoints/artists.rb")
+      it "creates a new resource module" do
+        assert File.exists?("lib/resources/artists.rb")
       end
 
-      it "creates an endpoint test" do
-        assert File.exists?("spec/endpoints/artists_spec.rb")
+      it "creates an resource test" do
+        assert File.exists?("spec/resources/artists_spec.rb")
       end
 
-      it "creates an endpoint acceptance test" do
+      it "creates an resource acceptance test" do
         assert File.exists?("spec/acceptance/artists_spec.rb")
       end
 
@@ -190,7 +190,7 @@ describe Pliny::Commands::Generator do
 
   describe "#url_path" do
     it "builds a URL path" do
-      @gen.args = ["endpoint", "resource_history"]
+      @gen.args = ["resource", "resource_history"]
       assert_equal "/resource-histories", @gen.url_path
     end
   end


### PR DESCRIPTION
The first is a bit confusing because each file is actually a
collection of endpoints. I like "resources" because it tells devs
what each file should expose, not to mention it sounds more
familiar to API developers and all.

Thoughts @geemus @mfine @brandur ?