### PR TITLE
Drop serializer from default model generation

### DIFF
--- a/lib/pliny/commands/generator.rb
+++ b/lib/pliny/commands/generator.rb
@@ -39,8 +39,6 @@ module Pliny::Commands
         create_model
         create_model_migration
         create_model_test
-        create_serializer
-        create_serializer_test
       when "scaffold"
         create_endpoint(scaffold: true)
         create_endpoint_test

--- a/test/commands/generator_test.rb
+++ b/test/commands/generator_test.rb
@@ -104,14 +104,6 @@ describe Pliny::Commands::Generator do
       it "creates a test" do
         assert File.exists?("spec/models/artist_spec.rb")
       end
-
-      it "creates a serializer" do
-        assert File.exists?("lib/serializers/artist_serializer.rb")
-      end
-
-      it "creates a serializer test" do
-        assert File.exists?("spec/serializers/artist_serializer_spec.rb")
-      end
     end
 
     describe "generating scaffolds" do


### PR DESCRIPTION
It already comes with the scaffold, doesn't seem needed at this
level.

/cc @mfine @brandur 
