### PR TITLE
Remove stray 'def' from Serializer template

### DIFF
--- a/lib/pliny/templates/serializer.erb
+++ b/lib/pliny/templates/serializer.erb
@@ -8,7 +8,7 @@
 <%   ident << "  " %>
 <% end %>
 <%=  ident %>class <%= modules.last %> < Serializers::Base
-<%=  ident %>  def structure(args) do |arg|
+<%=  ident %>  structure(args) do |arg|
 <%=  ident %>    {
 <%=  ident %>    }
 <%=  ident %>  end


### PR DESCRIPTION
Based on similar code in heroku/api [here](https://github.com/heroku/api/blob/master/lib/api/serializers/addon_serializer.rb#L6-L20), I think this is a typo.
