### PR TITLE
Add boolean config accessor

### DIFF
--- a/lib/pliny/config_helpers.rb
+++ b/lib/pliny/config_helpers.rb
@@ -3,18 +3,28 @@ module Pliny
     def optional(*attrs)
       attrs.each do |attr|
         instance_eval "def #{attr}; @#{attr} ||= ENV['#{attr.upcase}'] end", __FILE__, __LINE__
+        ConfigHelpers.add_question_method(attr)
       end
     end
 
     def mandatory(*attrs)
       attrs.each do |attr|
         instance_eval "def #{attr}; @#{attr} ||= ENV['#{attr.upcase}'] || raise('missing=#{attr.upcase}') end", __FILE__, __LINE__
+        ConfigHelpers.add_question_method(attr)
       end
     end
 
     def override(attrs)
       attrs.each do |attr, value|
         instance_eval "def #{attr}; @#{attr} ||= ENV['#{attr.upcase}'] || '#{value}'.to_s end", __FILE__, __LINE__
+        ConfigHelpers.add_question_method(attr)
+      end
+    end
+
+    def self.add_question_method(attr)
+      define_method "#{attr}?" do
+        return false if send(attr).nil?
+        !!(send(attr) =~ /\Atrue|yes|on\z/i || send(attr).to_i > 0)
       end
     end
   end


### PR DESCRIPTION
`Config.enable_foo` would return the string `"true"` or `"false"`
`Config.enable_foo?` would return `true` or `false`

As proposed in https://github.com/interagent/pliny-template/pull/108#issuecomment-45910189

I tried to write a test but I was unable, as it seems like I can't stub constants with `rr`
