### PR TITLE
Respect Pliny error status in instrumentation

### DIFF
--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -12,6 +12,9 @@ module Pliny
     class HTTPStatusError < Error
       attr_reader :status
 
+      # so that Sinatra respects are status code when catching an exception
+      alias :http_status :status
+
       def initialize(message = nil, id = nil, status = nil)
         meta    = Pliny::Errors::META[self.class]
         message = message || meta[1] + "."

--- a/test/extensions/instruments_test.rb
+++ b/test/extensions/instruments_test.rb
@@ -10,6 +10,10 @@ describe Pliny::Extensions::Instruments do
           status 201
           "hi"
         end
+
+        get "/error" do
+          raise Pliny::Errors::NotFound
+        end
       }
     end
   end
@@ -30,5 +34,13 @@ describe Pliny::Extensions::Instruments do
       status:          201
     ))
     get "/apps/123"
+  end
+
+  it "respects Pliny error status codes" do
+    mock(Pliny).log.with_any_args
+    mock(Pliny).log(hash_including(
+      status: 404
+    ))
+    get "/error"
   end
 end


### PR DESCRIPTION
This change makes sure that when a Pliny error is thrown, its status is 
respected while spitting out instrumentation data.
