### PR TITLE
Add content type to POST in endpoint_scaffold_acceptance_test

### DIFF
--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -28,6 +28,7 @@ describe Endpoints::<%= plural_class_name %> do
 
 =begin
   it "POST <%= url_path %>" do
+    header "Content-Type", "application/json"
     post "<%= url_path %>", MultiJson.encode({})
     last_response.status.should eq(201)
     assert_schema_conform


### PR DESCRIPTION
`Pliny::Helpers::Params` only looks at the body when the content type is `application/json`.
This PR is related to #31 
## Alternatives

``` ruby
post "<%= url_path %>", MultiJson.encode({}), { "CONTENT_TYPE" => "application/json" }
```

would be also possible.

Or custom helpers like `post_json`, `patch_json`, `get_json` etc.
