### PR TITLE
Change from old rspec should to expect

### DIFF
--- a/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -15,7 +15,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'GET <%= url_path %>' do
     it 'returns correct status code and conforms to schema' do
       get '<%= url_path %>'
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end
@@ -24,7 +24,7 @@ describe Endpoints::<%= plural_class_name %> do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
       post '<%= url_path %>', MultiJson.encode({})
-      last_response.status.should eq(201)
+      expect(last_response.status).to eq(201)
       assert_schema_conform
     end
   end
@@ -32,7 +32,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'GET <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       get "<%= url_path %>/123"
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end
@@ -41,7 +41,7 @@ describe Endpoints::<%= plural_class_name %> do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
       patch '<%= url_path %>/123', MultiJson.encode({})
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end
@@ -49,7 +49,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'DELETE <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       delete '<%= url_path %>/123'
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end

--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -23,7 +23,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'GET <%= url_path %>' do
     it 'returns correct status code and conforms to schema' do
       get '<%= url_path %>'
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end
@@ -33,7 +33,7 @@ describe Endpoints::<%= plural_class_name %> do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
       post '<%= url_path %>', MultiJson.encode({})
-      last_response.status.should eq(201)
+      expect(last_response.status).to eq(201)
       assert_schema_conform
     end
   end
@@ -42,7 +42,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'GET <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       get "<%= url_path %>/#{@<%= field_name %>.uuid}"
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end
@@ -51,7 +51,7 @@ describe Endpoints::<%= plural_class_name %> do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
       patch "<%= url_path %>/#{@<%= field_name %>.uuid}", MultiJson.encode({})
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end
@@ -59,7 +59,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'DELETE <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       delete "<%= url_path %>/#{@<%= field_name %>.uuid}"
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
       assert_schema_conform
     end
   end

--- a/lib/pliny/templates/endpoint_test.erb
+++ b/lib/pliny/templates/endpoint_test.erb
@@ -10,7 +10,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe "GET <%= url_path %>" do
     it "succeeds" do
       get "<%= url_path %>"
-      last_response.status.should eq(200)
+      expect(last_response.status).to eq(200)
     end
   end
 end


### PR DESCRIPTION
The preferred syntax for expectations was changed between rspec 2 and 3.  This
commit corrects the syntax in the generators to banish the deprecation warnings.
