### PR TITLE
Fix class name in serializer template

### DIFF
--- a/lib/pliny/commands/generator.rb
+++ b/lib/pliny/commands/generator.rb
@@ -188,13 +188,13 @@ module Pliny::Commands
     end
 
     def create_serializer
-      serializer = "./lib/serializers/#{name}_serializer.rb"
+      serializer = "./lib/serializers/#{name}.rb"
       render_template("serializer.erb", serializer, singular_class_name: singular_class_name)
       display "created serializer file #{serializer}"
     end
 
     def create_serializer_test
-      test = "./spec/serializers/#{name}_serializer_spec.rb"
+      test = "./spec/serializers/#{name}_spec.rb"
       render_template("serializer_test.erb", test, singular_class_name: singular_class_name)
       display "created test #{test}"
     end

--- a/lib/pliny/templates/serializer.erb
+++ b/lib/pliny/templates/serializer.erb
@@ -1,6 +1,6 @@
 <%
   modules = singular_class_name.split("::")
-  modules[0] = "Serializers::#{modules[0]}Serializer"
+  modules[0] = "Serializers::#{modules[0]}"
   ident = ""
 %>
 <% modules[0..-2].each do |m| %>

--- a/test/commands/generator_test.rb
+++ b/test/commands/generator_test.rb
@@ -153,11 +153,11 @@ describe Pliny::Commands::Generator do
       end
 
       it "creates a new serializer module" do
-        assert File.exists?("lib/serializers/artist_serializer.rb")
+        assert File.exists?("lib/serializers/artist.rb")
       end
 
       it "creates a test" do
-        assert File.exists?("spec/serializers/artist_serializer_spec.rb")
+        assert File.exists?("spec/serializers/artist_spec.rb")
       end
     end
 
@@ -179,11 +179,11 @@ describe Pliny::Commands::Generator do
       end
 
       it "creates a new serializer module" do
-        assert File.exists?("lib/serializers/artist_serializer.rb")
+        assert File.exists?("lib/serializers/artist.rb")
       end
 
       it "creates a test" do
-        assert File.exists?("spec/serializers/artist_serializer_spec.rb")
+        assert File.exists?("spec/serializers/artist_spec.rb")
       end
     end
   end


### PR DESCRIPTION
Currently the serializer generator returns a class of `Serializers::Foo` when the file name is `foo_serializer.rb`.

This corrects the class name by appending `Serializer`
