### PR TITLE
Add context with block for logging

### DIFF
--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -1,15 +1,17 @@
 module Pliny
   module Log
     def log(data, &block)
-      data = log_context.merge(data)
+      data = log_context.merge(local_context.merge(data))
       log_to_stream(stdout || $stdout, data, &block)
     end
 
     def context(data, &block)
-      old = log_context
-      RequestStore.store[:log_context] = log_context.merge(data)
-      block.call
-      RequestStore.store[:log_context] = old
+      old = local_context
+      self.local_context = old.merge(data)
+      res = block.call
+    ensure
+      local_context = old
+      res
     end
 
     def stdout=(stream)
@@ -21,6 +23,14 @@ module Pliny
     end
 
     private
+
+    def local_context
+      RequestStore.store[:local_context] ||= {}
+    end
+
+    def local_context=(h)
+      RequestStore.store[:local_context] = h
+    end
 
     def log_context
       RequestStore.store[:log_context] || {}

--- a/test/log_test.rb
+++ b/test/log_test.rb
@@ -31,4 +31,13 @@ describe Pliny::Log do
       Pliny.log(foo: "bar")
     end
   end
+
+  it "local context does not overwrite global" do
+    Pliny::RequestStore.store[:log_context] = { app: "pliny" }
+    mock(@io).puts "app=not_pliny foo=bar"
+    Pliny.context(app: "not_pliny") do
+      Pliny.log(foo: "bar")
+    end
+    assert Pliny::RequestStore.store[:log_context][:app] = "pliny"
+  end
 end


### PR DESCRIPTION
With this method, you get a simple helper to had context to your logging.

```
Pliny.context(api: :call_the_foreign_api) do
  Pliny.log(http_request: :get) # => api=call_the_foreign_api http_request=get
end
```
