### PR TITLE
Swap simple `gsub` for `tr`

### DIFF
--- a/lib/pliny/commands/generator/base.rb
+++ b/lib/pliny/commands/generator/base.rb
@@ -16,11 +16,11 @@ module Pliny::Commands
       end
 
       def singular_class_name
-        name.gsub(/-/, '_').singularize.camelize
+        name.tr('-', '_').singularize.camelize
       end
 
       def plural_class_name
-        name.gsub(/-/, '_').pluralize.camelize
+        name.tr('-', '_').pluralize.camelize
       end
 
       def field_name
@@ -32,7 +32,7 @@ module Pliny::Commands
       end
 
       def table_name
-        name.tableize.gsub('/', '_')
+        name.tableize.tr('/', '_')
       end
 
       def display(msg)

--- a/lib/pliny/commands/generator/endpoint.rb
+++ b/lib/pliny/commands/generator/endpoint.rb
@@ -37,7 +37,7 @@ module Pliny::Commands
       end
 
       def url_path
-        '/' + name.pluralize.gsub(/_/, '-')
+        '/' + name.pluralize.tr('_', '-')
       end
     end
   end

--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -21,7 +21,7 @@ module Pliny
       def initialize(message = nil, id = nil, status = nil)
         meta    = Pliny::Errors::META[self.class]
         message = message || meta[1] + "."
-        id      = id || meta[1].downcase.gsub(/ /, '_').to_sym
+        id      = id || meta[1].downcase.tr(' ', '_').to_sym
         @status = status || meta[0]
         super(message, id)
       end


### PR DESCRIPTION
TIL that `tr` is substantially faster than `gsub`.  Whilst this commit won't
shake the earth it'll add a small something to performance.

`gsub` vs `tr`:

```
   gsub   311878.2 (± 3.5%) i/s
   tr    1573891.1 (± 4.6%) i/s
```
