### PR TITLE
Remove #app from endpoint test

### DIFF
--- a/lib/pliny/templates/endpoint_test.erb
+++ b/lib/pliny/templates/endpoint_test.erb
@@ -3,11 +3,6 @@ require "spec_helper"
 describe Endpoints::<%= plural_class_name %> do
   include Rack::Test::Methods
 
-  def app
-    Endpoints::<%= plural_class_name %>
-
-  end
-
   describe "GET <%= url_path %>" do
     it "succeeds" do
       get "<%= url_path %>"


### PR DESCRIPTION
Will be defined automatically.

See https://github.com/interagent/pliny-template/commit/e02860f676181098c1b32facbd5dc1d0a3d40b0b
