### PR TITLE
Fix bug causing context propagation in logs

### DIFF
--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -10,7 +10,7 @@ module Pliny
       self.local_context = old.merge(data)
       res = block.call
     ensure
-      local_context = old
+      self.local_context = old
       res
     end
 

--- a/test/log_test.rb
+++ b/test/log_test.rb
@@ -40,4 +40,12 @@ describe Pliny::Log do
     end
     assert Pliny::RequestStore.store[:log_context][:app] = "pliny"
   end
+
+  it "local context does not propagate outside" do
+    Pliny::RequestStore.store[:log_context] = { app: "pliny" }
+    mock(@io).puts "app=pliny foo=bar"
+    Pliny.context(app: "not_pliny", test: 123) do
+    end
+    Pliny.log(foo: "bar")
+  end
 end


### PR DESCRIPTION
Before this patch, the behavior was the following

```
Pliny.context(baz: "qux") do
end
Pliny.log(foo: "bar") # => "foo=bar baz=qux"
```

Now it is the logical

```
Pliny.context(baz: "qux") do
end
Pliny.log(foo: "bar") # => "foo=bar"
```
