### PR TITLE
Save the Sequel database instance for seeds

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -40,7 +40,7 @@ namespace :db do
   task :seed do
     if File.exist?('./db/seeds.rb')
       database_urls.each do |database_url|
-        Sequel.connect(database_url)
+        @db = Sequel.connect(database_url)
         load 'db/seeds.rb'
       end
     end


### PR DESCRIPTION
This way you can refer to it to insert/modify rows, etc.

(Alternatively you can still require your app initializer and access your models/etc)