### PR TITLE
fix race condition with puts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.bundle

--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -39,11 +39,7 @@ module Pliny
     def log_to_stream(stream, data, &block)
       unless block
         str = unparse(data)
-        if RUBY_PLATFORM == "java"
-          stream.puts str
-        else
-          mtx.synchronize { stream.puts str }
-        end
+        stream.print(str + "\n")
       else
         data = data.dup
         start = Time.now
@@ -59,10 +55,6 @@ module Pliny
           raise
         end
       end
-    end
-
-    def mtx
-      @mtx ||= Mutex.new
     end
 
     def quote_string(k, v)

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -4,29 +4,29 @@ describe Pliny::Log do
   before do
     @io = StringIO.new
     Pliny.stdout = @io
-    stub(@io).puts
+    stub(@io).print
   end
 
   it "logs in structured format" do
-    mock(@io).puts "foo=bar baz=42"
+    mock(@io).print "foo=bar baz=42\n"
     Pliny.log(foo: "bar", baz: 42)
   end
 
   it "supports blocks to log stages and elapsed" do
-    mock(@io).puts "foo=bar at=start"
-    mock(@io).puts "foo=bar at=finish elapsed=0.000"
+    mock(@io).print "foo=bar at=start\n"
+    mock(@io).print "foo=bar at=finish elapsed=0.000\n"
     Pliny.log(foo: "bar") do
     end
   end
 
   it "merges context from RequestStore" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
-    mock(@io).puts "app=pliny foo=bar"
+    mock(@io).print "app=pliny foo=bar\n"
     Pliny.log(foo: "bar")
   end
 
   it "supports a context" do
-    mock(@io).puts "app=pliny foo=bar"
+    mock(@io).print "app=pliny foo=bar\n"
     Pliny.context(app: "pliny") do
       Pliny.log(foo: "bar")
     end
@@ -34,7 +34,7 @@ describe Pliny::Log do
 
   it "local context does not overwrite global" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
-    mock(@io).puts "app=not_pliny foo=bar"
+    mock(@io).print "app=not_pliny foo=bar\n"
     Pliny.context(app: "not_pliny") do
       Pliny.log(foo: "bar")
     end
@@ -43,7 +43,7 @@ describe Pliny::Log do
 
   it "local context does not propagate outside" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
-    mock(@io).puts "app=pliny foo=bar"
+    mock(@io).print "app=pliny foo=bar\n"
     Pliny.context(app: "not_pliny", test: 123) do
     end
     Pliny.log(foo: "bar")

--- a/spec/middleware/versioning_spec.rb
+++ b/spec/middleware/versioning_spec.rb
@@ -2,6 +2,11 @@ require "spec_helper"
 
 describe Pliny::Middleware::Versioning do
   include Rack::Test::Methods
+  before do
+    @io = StringIO.new
+    Pliny.stdout = @io
+    stub(@io).print
+  end
 
   def app
     Rack::Builder.new do


### PR DESCRIPTION
In ruby, `puts` has a race condition you can't get around w. the mutex.  Just call "print" with a string that already has the newline appended and you should be A-OK.
