### PR TITLE
lock prmd to 0.6 until we adapt to the 0.7 interface

### DIFF
--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport",  "~> 4.1",  ">= 4.1.0"
   gem.add_dependency "multi_json",     "~> 1.9",  ">= 1.9.3"
   gem.add_dependency "pg",             "~> 0.17", ">= 0.17.1"
-  gem.add_dependency "prmd",           "~> 0.1",  ">= 0.1.1"
+  gem.add_dependency "prmd",           "= 0.6.1"
   gem.add_dependency "sequel",         "~> 4.9",  ">= 4.9.0"
   gem.add_dependency "sinatra",        "~> 1.4",  ">= 1.4.5"
   gem.add_dependency "http_accept",    "~> 0.1",  ">= 0.1.5"


### PR DESCRIPTION
Getting these issues on 0.7:

```
       No such file or directory @ rb_sysopen - ./docs/schema/meta.json
     # /home/travis/build/interagent/pliny/vendor/bundle/ruby/2.1.0/gems/prmd-0.7.0/lib/prmd/load_schema_file.rb:13:in `initialize'
```
