### PR TITLE
Add Gemfile.lock back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-Gemfile.lock
 .bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,86 @@
+PATH
+  remote: .
+  specs:
+    pliny (0.5.0)
+      activesupport (~> 4.1, >= 4.1.0)
+      http_accept (~> 0.1, >= 0.1.5)
+      multi_json (~> 1.9, >= 1.9.3)
+      pg (~> 0.17, >= 0.17.1)
+      prmd (= 0.6.1)
+      sequel (~> 4.9, >= 4.9.0)
+      sinatra (~> 1.4, >= 1.4.5)
+      sinatra-router (~> 0.2, >= 0.2.3)
+      thor (~> 0.19, >= 0.19.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.1.7)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    erubis (2.7.0)
+    http_accept (0.1.6)
+    i18n (0.6.11)
+    json (1.8.1)
+    json_schema (0.3.1)
+    method_source (0.8.2)
+    minitest (5.4.2)
+    multi_json (1.10.1)
+    pg (0.17.1)
+    prmd (0.6.1)
+      erubis (~> 2.7)
+      json_schema (~> 0.1)
+    pry (0.10.0)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    rake (0.9.6)
+    rr (1.1.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.5)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.2)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.1)
+    sequel (4.16.0)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    sinatra-router (0.2.3)
+      sinatra (~> 1.4)
+    slop (3.6.0)
+    thor (0.19.1)
+    thread_safe (0.3.4)
+    tilt (1.4.1)
+    timecop (0.7.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pliny!
+  pry
+  rack-test
+  rake (~> 0.8, >= 0.8.7)
+  rr
+  rspec
+  timecop


### PR DESCRIPTION
Hey folks,

While it's debatable whether Gemfile.lock should be in the template at all, I think it really needs to be here in the gem otherwise different developers will get different dependencies, and then it's hard to know if anything broke/etc.

As an example, Travis just ran the build of #95 against a newer version of prmd, despite no changes in the gemspec on that branch.
