### PR TITLE
Allow for different postgres host and port.

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -51,8 +51,8 @@ namespace :db do
 
   desc "Create the database"
   task :create do
-    db = Sequel.connect("postgres:///postgres")
     database_urls.each do |database_url|
+      db = Sequel.connect("#{postgres_location_from_uri(database_url)}/postgres")
       exists = false
       name = name_from_uri(database_url)
       begin
@@ -67,8 +67,8 @@ namespace :db do
 
   desc "Drop the database"
   task :drop do
-    db = Sequel.connect("postgres:///postgres")
     database_urls.each do |database_url|
+      db = Sequel.connect("#{postgres_location_from_uri(database_url)}/postgres")
       name = name_from_uri(database_url)
       db.run(%{DROP DATABASE IF EXISTS "#{name}"})
       puts "Dropped `#{name}`"
@@ -143,5 +143,11 @@ namespace :db do
 
   def name_from_uri(uri)
     URI.parse(uri).path[1..-1]
+  end
+
+  def postgres_location_from_uri(uri)
+    p = URI.parse(uri)
+    port = p.port ? ":#{p.port}" : ""
+    "#{p.scheme}://#{p.host}#{port}"
   end
 end


### PR DESCRIPTION
Previously the host and port information specified via the `DATABASE_URL` in `.env` would be ignored when dropping/creating the database. This commit fixes the problem.

Fixes https://github.com/interagent/pliny/issues/99.
