### PR TITLE
Fix exception handling with respect to Rollbar

### DIFF
--- a/lib/pliny/middleware/rescue_errors.rb
+++ b/lib/pliny/middleware/rescue_errors.rb
@@ -8,6 +8,9 @@ module Pliny::Middleware
     def call(env)
       @app.call(env)
     rescue Pliny::Errors::Error => e
+      # blank out this field so that the error is not picked up by Rollbar
+      env["sinatra.error"] = nil
+
       Pliny::Errors::Error.render(e)
     rescue Exception => e
       if @raise

--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -16,10 +16,6 @@ module Endpoints
       also_reload '../**/*.rb'
     end
 
-    error Pliny::Errors::Error do
-      Pliny::Errors::Error.render(env["sinatra.error"])
-    end
-
     not_found do
       content_type :json
       status 404

--- a/lib/template/lib/routes.rb
+++ b/lib/template/lib/routes.rb
@@ -1,4 +1,5 @@
 Routes = Rack::Builder.new do
+  use Rollbar::Middleware::Sinatra
   use Pliny::Middleware::RescueErrors, raise: Config.raise_errors?
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID


### PR DESCRIPTION
Makes some minor fixes to get this sytem working:

* Blank out `sinatra.error` when catching a Pliny exception so that
 Rollbar doesn't see it.
* Add Rollbar Sinatra middleware.
* Remove base endpoint error handling block for Pliny errors (everything
 gets sent up to the middleware).
* Use Rollbar's new `disable_monkey_patch` config as written by Pedro.
* Bump Rollbar version to get new config.