### PR TITLE
re-add require of pliny/version

### DIFF
--- a/lib/pliny/commands/creator.rb
+++ b/lib/pliny/commands/creator.rb
@@ -1,3 +1,4 @@
+require 'pliny/version'
 require 'fileutils'
 require 'pathname'
 require 'uri'


### PR DESCRIPTION
I accidentally removed it in b3d41186