### PR TITLE
Ensure we seed when running db:setup

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -130,7 +130,7 @@ namespace :db do
   end
 
   desc "Setup the database"
-  task :setup => [:drop, :create, "schema:load", :migrate]
+  task :setup => [:drop, :create, "schema:load", :migrate, :seed]
 
   private
 


### PR DESCRIPTION
We're not running `db:seed` after setup at the moment.  We can add this to `bin/setup`, or make this change here.