### PR TITLE
Only check spec.described_class if set.

### DIFF
--- a/lib/template/spec/support/auto_define_rack_app.rb
+++ b/lib/template/spec/support/auto_define_rack_app.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
   config.before(:context) do |spec|
     # weird ruby syntax, but test if the described_class inherits Sinatra::Base:
-    if !@rack_app && spec.described_class < Sinatra::Base
+    if !@rack_app && spec.described_class && spec.described_class < Sinatra::Base
       @rack_app = spec.described_class
     end
   end


### PR DESCRIPTION
This allows a string as the argument to `describe`.