### PR TITLE
Check media_type instead of content_type.

### DIFF
--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -7,7 +7,7 @@ module Pliny::Helpers
     private
 
     def parse_body_params
-      if request.content_type == "application/json"
+      if request.media_type == "application/json"
         p = indifferent_params(MultiJson.decode(request.body.read))
         request.body.rewind
         p


### PR DESCRIPTION
This will allow Content-Types header values such as "application/json;charset=utf-8".

See [the rack docs](http://www.rubydoc.info/github/rack/rack/Rack/Request#media_type-instance_method).