### PR TITLE
Default timeout

### DIFF
--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -27,7 +27,7 @@ module Config
   override :rack_env,         'development', string
   override :raise_errors,     false,         bool
   override :root,             File.expand_path("../../", __FILE__), string
-  override :timeout,          45,    int
+  override :timeout,          10,    int
   override :force_ssl,        true,  bool
   override :versioning,       false, bool
   override :pretty_json,      false, bool


### PR DESCRIPTION
The current default timeout in a generated app is of 45 seconds.
This can generate H12s very easily, and a request should be refactored way before it uses that long.

This PR changes the default value of timeout to 10 seconds.