### PR TITLE
Alternatively support the `X-` prefix on the `Request-Id` field

### DIFF
--- a/lib/pliny/middleware/request_id.rb
+++ b/lib/pliny/middleware/request_id.rb
@@ -30,13 +30,23 @@ module Pliny::Middleware
     private
 
     def extract_request_ids(env)
-      request_ids = []
-      if env["HTTP_REQUEST_ID"]
-        request_ids = env["HTTP_REQUEST_ID"].split(",")
-        request_ids.map! { |id| id.strip }
-        request_ids.select! { |id| id =~ UUID_PATTERN }
-      end
+      request_ids = raw_request_ids(env)
+      request_ids.map! { |id| id.strip }
+      request_ids.select! { |id| id =~ UUID_PATTERN }
       request_ids
+    end
+
+    def raw_request_ids(env)
+      # We had a little disagreement around the inception of the Request-Id
+      # field as to whether it should be prefixed with `X-` or not. API went
+      # with no prefix, but Hermes went with one. Support both formats on
+      # input.
+      %w(HTTP_REQUEST_ID HTTP_X_REQUEST_ID).inject([]) do |request_ids, key|
+        if ids = env[key]
+          request_ids += ids.split(",")
+        end
+        request_ids
+      end
     end
   end
 end

--- a/lib/pliny/middleware/request_id.rb
+++ b/lib/pliny/middleware/request_id.rb
@@ -2,8 +2,14 @@
 
 module Pliny::Middleware
   class RequestID
+    # note that this pattern supports either a full UUID, or a "squashed" UUID
+    # like the kind Hermes sends:
+    #
+    #     full:     01234567-89ab-cdef-0123-456789abcdef
+    #     squashed: 0123456789abcdef0123456789abcdef
+    #
     UUID_PATTERN =
-      /\A[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\Z/
+      /\A[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12}\Z/
 
     def initialize(app)
       @app = app

--- a/spec/middleware/request_id_spec.rb
+++ b/spec/middleware/request_id_spec.rb
@@ -25,4 +25,11 @@ describe Pliny::Middleware::RequestID do
     get "/"
     assert_includes last_response.body, id
   end
+
+  it "accepts incoming request IDs with an `X-` prefix" do
+    id = SecureRandom.uuid
+    header "X-Request-Id", id
+    get "/"
+    assert_includes last_response.body, id
+  end
 end


### PR DESCRIPTION
So that Pliny apps can play nicely with Hermes out of the box [1].

[1] https://devcenter.heroku.com/articles/http-request-id