### PR TITLE
Just run the base 404 responder on Sinatra::NotFound.

### DIFF
--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -16,7 +16,7 @@ module Endpoints
       also_reload '../**/*.rb'
     end
 
-    not_found do
+    error Sinatra::NotFound do
       content_type :json
       status 404
       "{}"


### PR DESCRIPTION
`not_found` will run the handler on both `Sinatra::NotFound` and any response with status 404. This means if a route purposely 404s (probably with a helpful error message) the block passed to `not_found` will overwrite it.