### PR TITLE
Use Minitest syntax in scaffold endpoint template

### DIFF
--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -23,7 +23,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'GET <%= url_path %>' do
     it 'returns correct status code and conforms to schema' do
       get '<%= url_path %>'
-      expect(last_response.status).to eq(200)
+      assert_equal 200, last_response.status
       assert_schema_conform
     end
   end
@@ -33,7 +33,7 @@ describe Endpoints::<%= plural_class_name %> do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
       post '<%= url_path %>', MultiJson.encode({})
-      expect(last_response.status).to eq(201)
+      assert_equal 201, last_response.status
       assert_schema_conform
     end
   end
@@ -42,7 +42,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'GET <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       get "<%= url_path %>/#{@<%= field_name %>.uuid}"
-      expect(last_response.status).to eq(200)
+      assert_equal 200, last_response.status
       assert_schema_conform
     end
   end
@@ -51,7 +51,7 @@ describe Endpoints::<%= plural_class_name %> do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
       patch "<%= url_path %>/#{@<%= field_name %>.uuid}", MultiJson.encode({})
-      expect(last_response.status).to eq(200)
+      assert_equal 200, last_response.status
       assert_schema_conform
     end
   end
@@ -59,7 +59,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'DELETE <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       delete "<%= url_path %>/#{@<%= field_name %>.uuid}"
-      expect(last_response.status).to eq(200)
+      assert_equal 200, last_response.status
       assert_schema_conform
     end
   end


### PR DESCRIPTION
We're already using Minitest syntax over in the standard endpoint test
and also have it configured in the `spec_helper`, so let's consolidate
on it.

Fixes #132.