### PR TITLE
Add default log context

### DIFF
--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -1,7 +1,7 @@
 module Pliny
   module Log
     def log(data, &block)
-      data = log_context.merge(local_context.merge(data))
+      data = default_context.merge(log_context.merge(local_context.merge(data)))
       log_to_stream(stdout || $stdout, data, &block)
     end
 
@@ -12,6 +12,14 @@ module Pliny
     ensure
       self.local_context = old
       res
+    end
+
+    def default_context=(default_context)
+      @default_context = default_context
+    end
+
+    def default_context
+      @default_context || {}
     end
 
     def stdout=(stream)

--- a/lib/template/config/initializers/log.rb
+++ b/lib/template/config/initializers/log.rb
@@ -1,0 +1,1 @@
+Pliny.default_context = {}

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -8,7 +8,7 @@ describe Pliny::Log do
   end
 
   after do
-    Pliny.default_context = { }
+    Pliny.default_context = {}
   end
 
   it "logs in structured format" do

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -46,7 +46,7 @@ describe Pliny::Log do
     Pliny.default_context = { app: "pliny" }
     mock(@io).print "app=not_pliny foo=bar\n"
     Pliny.log(app: 'not_pliny', foo: "bar")
-    assert Pliny.default_context[:app] = "pliny"
+    assert Pliny.default_context[:app] == "pliny"
   end
 
   it "local context does not overwrite request context" do
@@ -55,7 +55,7 @@ describe Pliny::Log do
     Pliny.context(app: "not_pliny") do
       Pliny.log(foo: "bar")
     end
-    assert Pliny::RequestStore.store[:log_context][:app] = "pliny"
+    assert Pliny::RequestStore.store[:log_context][:app] == "pliny"
   end
 
   it "local context does not propagate outside" do

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -7,6 +7,10 @@ describe Pliny::Log do
     stub(@io).print
   end
 
+  after do
+    Pliny.default_context = { }
+  end
+
   it "logs in structured format" do
     mock(@io).print "foo=bar baz=42\n"
     Pliny.log(foo: "bar", baz: 42)
@@ -17,6 +21,12 @@ describe Pliny::Log do
     mock(@io).print "foo=bar at=finish elapsed=0.000\n"
     Pliny.log(foo: "bar") do
     end
+  end
+
+  it "merges default context" do
+    Pliny.default_context = { app: "pliny" }
+    mock(@io).print "app=pliny foo=bar\n"
+    Pliny.log(foo: "bar")
   end
 
   it "merges context from RequestStore" do
@@ -32,7 +42,14 @@ describe Pliny::Log do
     end
   end
 
-  it "local context does not overwrite global" do
+  it "local context does not overwrite default context" do
+    Pliny.default_context = { app: "pliny" }
+    mock(@io).print "app=not_pliny foo=bar\n"
+    Pliny.log(app: 'not_pliny', foo: "bar")
+    assert Pliny.default_context[:app] = "pliny"
+  end
+
+  it "local context does not overwrite request context" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
     mock(@io).print "app=not_pliny foo=bar\n"
     Pliny.context(app: "not_pliny") do


### PR DESCRIPTION
Ability to set default log contexts that are not tied to requests. This allows an initializer to set `{ app: 'my-app' }` which will be picked up by `Pliny::Extensions::Instruments`. The `Instruments` are currently invoked before the `RequestStore` is seeded.