### PR TITLE
Use PLINY_ENV over RACK_ENV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ notifications:
     template:
       - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} (<a href="%{build_url}">Details</a> | <a href="%{compare_url}">Change view</a>)'
     format: html
+  email: false
 script: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ $ bundle exec pliny-generate migration fix_something
 created migration ./db/migrate/1395873228_fix_something.rb
 
 $ bundle exec pliny-generate schema artists
-created schema file ./docs/schema/schemata/artist.yaml
-rebuilt ./docs/schema.json
+created schema file ./schema/schemata/artist.yaml
+rebuilt ./schema/schema.json
 ```
 
 To test your application:

--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -1,7 +1,7 @@
 module Pliny
   module Log
     def log(data, &block)
-      data = log_context.merge(local_context.merge(data))
+      data = default_context.merge(log_context.merge(local_context.merge(data)))
       log_to_stream(stdout || $stdout, data, &block)
     end
 
@@ -12,6 +12,14 @@ module Pliny
     ensure
       self.local_context = old
       res
+    end
+
+    def default_context=(default_context)
+      @default_context = default_context
+    end
+
+    def default_context
+      @default_context || {}
     end
 
     def stdout=(stream)

--- a/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -9,7 +9,7 @@ describe Endpoints::<%= plural_class_name %> do
   end
 
   def schema_path
-    "./docs/schema.json"
+    "./schema/schema.json"
   end
 
   describe 'GET <%= url_path %>' do

--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -9,7 +9,7 @@ describe Endpoints::<%= plural_class_name %> do
   end
 
   def schema_path
-    "./docs/schema.json"
+    "./schema/schema.json"
   end
 
   before do

--- a/lib/pliny/version.rb
+++ b/lib/pliny/version.rb
@@ -1,3 +1,3 @@
 module Pliny
-  VERSION = "0.7.2"
+  VERSION = "0.7.3"
 end

--- a/lib/template/.env.sample
+++ b/lib/template/.env.sample
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://localhost/pliny-development
-RACK_ENV=development
+PLINY_ENV=development
 TZ=UTC
 RAISE_ERRORS=true
 FORCE_SSL=false

--- a/lib/template/.env.test
+++ b/lib/template/.env.test
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://localhost/pliny-test
-RACK_ENV=test
+PLINY_ENV=test
 TZ=UTC
 RAISE_ERRORS=true
 FORCE_SSL=false

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -11,7 +11,6 @@ module Config
 
   # Mandatory -- exception is raised for these variables when missing.
   mandatory :database_url, string
-  mandatory :pliny_env, string
 
   # Optional -- value is returned or `nil` if it wasn't present.
   optional :placeholder,         string

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -11,6 +11,7 @@ module Config
 
   # Mandatory -- exception is raised for these variables when missing.
   mandatory :database_url, string
+  mandatory :pliny_env, string
 
   # Optional -- value is returned or `nil` if it wasn't present.
   optional :placeholder,         string
@@ -25,6 +26,7 @@ module Config
   override :puma_min_threads, 1,    int
   override :puma_workers,     3,    int
   override :rack_env,         'development', string
+  override :pliny_env,        'development', string
   override :raise_errors,     false,         bool
   override :root,             File.expand_path("../../", __FILE__), string
   override :timeout,          10,    int

--- a/lib/template/config/initializers/log.rb
+++ b/lib/template/config/initializers/log.rb
@@ -1,0 +1,1 @@
+Pliny.default_context = {}

--- a/lib/template/config/puma.rb
+++ b/lib/template/config/puma.rb
@@ -1,6 +1,6 @@
 require "./config/config"
 
-environment Config.rack_env
+environment Config.pliny_env
 port Config.port
 quiet
 threads Config.puma_min_threads, Config.puma_max_threads

--- a/lib/template/spec/spec_helper.rb
+++ b/lib/template/spec/spec_helper.rb
@@ -5,7 +5,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 #
-ENV["PLINY_ENV"] = "test"
+ENV["RACK_ENV"] = "test"
 
 require "bundler"
 Bundler.require(:default, :test)

--- a/lib/template/spec/spec_helper.rb
+++ b/lib/template/spec/spec_helper.rb
@@ -5,7 +5,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 #
-ENV["RACK_ENV"] = "test"
+ENV["PLINY_ENV"] = "test"
 
 require "bundler"
 Bundler.require(:default, :test)
@@ -27,7 +27,7 @@ RSpec.configure do |config|
   config.before :all do
     load('db/seeds.rb') if File.exist?('db/seeds.rb')
   end
-  
+
   config.before :each do
     DatabaseCleaner.start
   end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -8,7 +8,7 @@ describe Pliny::Log do
   end
 
   after do
-    Pliny.default_context = { }
+    Pliny.default_context = {}
   end
 
   it "logs in structured format" do

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -46,7 +46,7 @@ describe Pliny::Log do
     Pliny.default_context = { app: "pliny" }
     mock(@io).print "app=not_pliny foo=bar\n"
     Pliny.log(app: 'not_pliny', foo: "bar")
-    assert Pliny.default_context[:app] = "pliny"
+    assert Pliny.default_context[:app] == "pliny"
   end
 
   it "local context does not overwrite request context" do
@@ -55,7 +55,7 @@ describe Pliny::Log do
     Pliny.context(app: "not_pliny") do
       Pliny.log(foo: "bar")
     end
-    assert Pliny::RequestStore.store[:log_context][:app] = "pliny"
+    assert Pliny::RequestStore.store[:log_context][:app] == "pliny"
   end
 
   it "local context does not propagate outside" do

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -7,6 +7,10 @@ describe Pliny::Log do
     stub(@io).print
   end
 
+  after do
+    Pliny.default_context = { }
+  end
+
   it "logs in structured format" do
     mock(@io).print "foo=bar baz=42\n"
     Pliny.log(foo: "bar", baz: 42)
@@ -17,6 +21,12 @@ describe Pliny::Log do
     mock(@io).print "foo=bar at=finish elapsed=0.000\n"
     Pliny.log(foo: "bar") do
     end
+  end
+
+  it "merges default context" do
+    Pliny.default_context = { app: "pliny" }
+    mock(@io).print "app=pliny foo=bar\n"
+    Pliny.log(foo: "bar")
   end
 
   it "merges context from RequestStore" do
@@ -32,7 +42,14 @@ describe Pliny::Log do
     end
   end
 
-  it "local context does not overwrite global" do
+  it "local context does not overwrite default context" do
+    Pliny.default_context = { app: "pliny" }
+    mock(@io).print "app=not_pliny foo=bar\n"
+    Pliny.log(app: 'not_pliny', foo: "bar")
+    assert Pliny.default_context[:app] = "pliny"
+  end
+
+  it "local context does not overwrite request context" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
     mock(@io).print "app=not_pliny foo=bar\n"
     Pliny.context(app: "not_pliny") do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # make sure this is set before Sinatra is required
-ENV["RACK_ENV"] = "test"
+ENV["PLINY_ENV"] = "test"
 
 require "bundler"
 Bundler.require

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # make sure this is set before Sinatra is required
-ENV["PLINY_ENV"] = "test"
+ENV["RACK_ENV"] = "test"
 
 require "bundler"
 Bundler.require


### PR DESCRIPTION
`RACK_ENV` shouldn't be used to determine the environment past `development` or `deployment`.

See http://www.hezmatt.org/~mpalmer/blog/2013/10/13/rack_env-its-not-for-you.html

In fact, it can even cause some issues if your app is using unicorn, as they're including internal rack middlewares relying on RACK_ENV to have the deployment value.
See https://github.com/defunkt/unicorn/blob/master/lib/unicorn.rb#L56-L79

Rack itself does that too.
https://github.com/rack/rack/blob/4e4ab39b0508aa3e59f5d7e53696ef6ae7c220ed/lib/rack/server.rb#L228

This PR adds `PLINY_ENV` for dictating environment, and leaves `RACK_ENV` as it should be.

(note there are some failing tests, but I have no idea why these are happening.  Could do with some help)