### PR TITLE
Timeout postgres queries after Config.timeout

### DIFF
--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -28,6 +28,7 @@ module Config
   override :raise_errors,     false,         bool
   override :root,             File.expand_path("../../", __FILE__), string
   override :timeout,          10,    int
+  override :database_timeout, 10,    int
   override :force_ssl,        true,  bool
   override :versioning,       false, bool
   override :pretty_json,      false, bool

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,3 +1,3 @@
 Sequel.connect(Config.database_url,
                max_connections: Config.db_pool,
-               after_connect: -> (c) { c.execute "set statement_timeout = '#{Config.timeout}s'"  })
+               after_connect: -> (c) { c.execute "set statement_timeout = '#{Config.database_timeout}s'"  })

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,1 +1,3 @@
-Sequel.connect(Config.database_url, max_connections: Config.db_pool)
+Sequel.connect(Config.database_url,
+               max_connections: Config.db_pool,
+               after_connect: -> (c) { c.execute "set statement_timeout = '#{Config.timeout}s'"  })


### PR DESCRIPTION
We're having the [HTTP requests timeout after `Config.timeout` seconds](https://github.com/interagent/pliny/blob/master/lib/template/lib/routes.rb#L7).  We should probably make sure that queries aren't running past this time otherwise it's just a waste.

The only issue I can think of here is around migrations, but those seem to [use a different connection](https://github.com/interagent/pliny/blob/master/lib/pliny/tasks/db.rake#L12)