### PR TITLE
Set application_name

### DIFF
--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,4 +1,5 @@
 database_setup_proc = lambda do |conn|
+  # identify postgres connections coming from this process in pg_stat_activity
   process_identifier = ENV["DYNO"] || File.basename($0).gsub(/\W+/, "_")
   conn.execute "SET statement_timeout = '#{Config.database_timeout}s'"
   conn.execute "SET application_name = #{process_identifier}"

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,3 +1,7 @@
+database_setup_proc = lambda do |conn|
+  conn.execute "set statement_timeout = '#{Config.database_timeout}s'"
+end
+
 Sequel.connect(Config.database_url,
-               max_connections: Config.db_pool,
-               after_connect: -> (c) { c.execute "set statement_timeout = '#{Config.database_timeout}s'"  })
+  max_connections: Config.db_pool,
+  after_connect: database_setup_proc)

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,6 +1,6 @@
 database_setup_proc = lambda do |conn|
-  conn.execute "set statement_timeout = '#{Config.database_timeout}s'"
-  conn.execute "set application_name = #{File.basename($0)}"
+  conn.execute "SET statement_timeout = '#{Config.database_timeout}s'"
+  conn.execute "SET application_name = #{File.basename($0)}"
 end
 
 Sequel.connect(Config.database_url,

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,5 +1,6 @@
 database_setup_proc = lambda do |conn|
   conn.execute "set statement_timeout = '#{Config.database_timeout}s'"
+  conn.execute "set application_name = #{File.basename($0)}"
 end
 
 Sequel.connect(Config.database_url,

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,6 +1,7 @@
 database_setup_proc = lambda do |conn|
+  process_identifier = ENV["DYNO"] || File.basename($0)
   conn.execute "SET statement_timeout = '#{Config.database_timeout}s'"
-  conn.execute "SET application_name = #{File.basename($0)}"
+  conn.execute "SET application_name = #{process_identifier}"
 end
 
 Sequel.connect(Config.database_url,

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -1,5 +1,5 @@
 database_setup_proc = lambda do |conn|
-  process_identifier = ENV["DYNO"] || File.basename($0)
+  process_identifier = ENV["DYNO"] || File.basename($0).gsub(/\W+/, "_")
   conn.execute "SET statement_timeout = '#{Config.database_timeout}s'"
   conn.execute "SET application_name = #{process_identifier}"
 end


### PR DESCRIPTION
To help match a process with the corresponding entry in `pg_stat_activity`.

`DYNO` is set by Heroku – if present the process will be identified like `web.1`.

Otherwise it just uses the current process name, which could be as simple as `console`, or complicated as `puma: cluster worker 0: 78289 [myapp]`. This is probably not ideal for many, but at least it sets a precedence so developers can add whatever else is relevant in their deployment setup (ip, instance id, docker container id, etc).
