### PR TITLE
Set Sinatra root

### DIFF
--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -9,6 +9,7 @@ module Endpoints
 
     set :dump_errors, false
     set :raise_errors, true
+    set :root, Config.root
     set :show_exceptions, false
 
     configure :development do


### PR DESCRIPTION
This way people can use `public/` and `views/` if they do want to.

(I realize Pliny was never intended to become a web framework, but it's awesome to be able to package a front-end JS framework with it, like Ember or Angular).