### PR TITLE
Rename uuid field to just id

### DIFF
--- a/lib/pliny/templates/endpoint_scaffold.erb
+++ b/lib/pliny/templates/endpoint_scaffold.erb
@@ -18,19 +18,19 @@ module Endpoints
       end
 
       get "/:id" do |id|
-        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %> = <%= singular_class_name %>.first(id: id) || halt(404)
         encode serialize(<%= field_name %>)
       end
 
       patch "/:id" do |id|
-        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %> = <%= singular_class_name %>.first(id: id) || halt(404)
         # warning: not safe
         #<%= field_name %>.update(body_params)
         encode serialize(<%= field_name %>)
       end
 
       delete "/:id" do |id|
-        <%= field_name %> = <%= singular_class_name %>.first(uuid: id) || halt(404)
+        <%= field_name %> = <%= singular_class_name %>.first(id: id) || halt(404)
         <%= field_name %>.destroy
         encode serialize(<%= field_name %>)
       end

--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -41,7 +41,7 @@ describe Endpoints::<%= plural_class_name %> do
 
   describe 'GET <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
-      get "<%= url_path %>/#{@<%= field_name %>.uuid}"
+      get "<%= url_path %>/#{@<%= field_name %>.id}"
       assert_equal 200, last_response.status
       assert_schema_conform
     end
@@ -50,7 +50,7 @@ describe Endpoints::<%= plural_class_name %> do
   describe 'PATCH <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
-      patch "<%= url_path %>/#{@<%= field_name %>.uuid}", MultiJson.encode({})
+      patch "<%= url_path %>/#{@<%= field_name %>.id}", MultiJson.encode({})
       assert_equal 200, last_response.status
       assert_schema_conform
     end
@@ -58,7 +58,7 @@ describe Endpoints::<%= plural_class_name %> do
 
   describe 'DELETE <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
-      delete "<%= url_path %>/#{@<%= field_name %>.uuid}"
+      delete "<%= url_path %>/#{@<%= field_name %>.id}"
       assert_equal 200, last_response.status
       assert_schema_conform
     end

--- a/lib/pliny/templates/model_migration.erb
+++ b/lib/pliny/templates/model_migration.erb
@@ -1,12 +1,12 @@
 Sequel.migration do
   change do
     create_table(:<%= table_name %>) do
+      id           :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
       timestamptz  :created_at, default: Sequel.function(:now), null: false
 <% if paranoid %>
       timestamptz  :deleted_at
 <% end %>
       timestamptz  :updated_at
-      uuid         :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
     end
   end
 end

--- a/lib/pliny/templates/model_migration.erb
+++ b/lib/pliny/templates/model_migration.erb
@@ -1,7 +1,7 @@
 Sequel.migration do
   change do
     create_table(:<%= table_name %>) do
-      id           :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
+      uuid         :id, default: Sequel.function(:uuid_generate_v4), primary_key: true
       timestamptz  :created_at, default: Sequel.function(:now), null: false
 <% if paranoid %>
       timestamptz  :deleted_at

--- a/lib/pliny/templates/serializer.erb
+++ b/lib/pliny/templates/serializer.erb
@@ -11,7 +11,7 @@
 <%=  ident %>  structure(:default) do |arg|
 <%=  ident %>    {
 <%=  ident %>      created_at: arg.created_at.try(:iso8601),
-<%=  ident %>      id:         arg.uuid,
+<%=  ident %>      id:         arg.id,
 <%=  ident %>      updated_at: arg.updated_at.try(:iso8601),
 <%=  ident %>    }
 <%=  ident %>  end


### PR DESCRIPTION
Calling the primary row identifier "uuid" is weird - that is definitely the column type, but not a good name/label.

This becomes very clear when doing associations: feels weird to call an association column `author_uuid`, for instance.