### PR TITLE
Show Sequel logs on db:migrate/rollback

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -1,3 +1,4 @@
+require "logger"
 require "sequel"
 require "sequel/extensions/migration"
 require "uri"
@@ -10,6 +11,7 @@ namespace :db do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
       db = Sequel.connect(database_url)
+      db.loggers << Logger.new($stdout)
       Sequel::Migrator.apply(db, "./db/migrate")
       puts "Migrated `#{name_from_uri(database_url)}`"
     end
@@ -21,6 +23,7 @@ namespace :db do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
       db = Sequel.connect(database_url)
+      db.loggers << Logger.new($stdout)
       Sequel::Migrator.apply(db, "./db/migrate", -1)
       puts "Rolled back `#{name_from_uri(database_url)}`"
     end


### PR DESCRIPTION
Got a little annoyed not knowing what was going on when running these.

Ideally this would be a bit closer to Rails' (less verbose, better formatted) but it doesn't seem like Sequel offers primitives for that. At any rate this seems like improvement.

Sample output:

```
$ rake db:migrate
I, [2015-04-22T22:08:19.361459 #45583]  INFO -- : (0.000187s) SET standard_conforming_strings = ON
I, [2015-04-22T22:08:19.361677 #45583]  INFO -- : (0.000124s) SET client_min_messages = 'WARNING'
I, [2015-04-22T22:08:19.361811 #45583]  INFO -- : (0.000092s) SET DateStyle = 'ISO'
I, [2015-04-22T22:08:19.362680 #45583]  INFO -- : (0.000667s) SELECT NULL AS "nil" FROM "schema_migrations" LIMIT 1
I, [2015-04-22T22:08:19.363080 #45583]  INFO -- : (0.000173s) SELECT * FROM "schema_migrations" LIMIT 1
I, [2015-04-22T22:08:19.363688 #45583]  INFO -- : (0.000392s) SELECT "filename" FROM "schema_migrations" ORDER BY "filename"
I, [2015-04-22T22:08:20.524823 #45583]  INFO -- : Begin applying migration 1429739705_remove_editorial_from_places.rb, direction: up
I, [2015-04-22T22:08:20.525001 #45583]  INFO -- : (0.000105s) BEGIN
I, [2015-04-22T22:08:20.525346 #45583]  INFO -- : (0.000197s) ALTER TABLE "places" DROP COLUMN "editorial"
I, [2015-04-22T22:08:20.525660 #45583]  INFO -- : (0.000158s) INSERT INTO "schema_migrations" ("filename") VALUES ('1429739705_remove_editorial_from_places.rb') RETURNING "filename"
I, [2015-04-22T22:08:20.526022 #45583]  INFO -- : (0.000299s) COMMIT
I, [2015-04-22T22:08:20.526073 #45583]  INFO -- : Finished applying migration 1429739705_remove_editorial_from_places.rb, direction: up, took 0.001245 seconds
Migrated `mr-development`
```