### PR TITLE
Fix db:rollback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 1.9.3
 addons:
   postgresql: '9.3'
+before_script:
+  - createdb pliny-gem-test
 sudo: false
 cache: bundler
 notifications:

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -23,6 +23,16 @@ module Pliny
       Sequel::Migrator.apply(db, "./db/migrate")
     end
 
+    def rollback
+      migrations = Dir["./db/migrate/*.rb"].map { |f| File.basename(f).to_i }.sort
+      current = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename].to_i
+      target = 0 # by default, rollback everything
+      if i = migrations.index(current)
+        target = migrations[i - 1] || 0
+      end
+      Sequel::Migrator.apply(db, "./db/migrate", target)
+    end
+
     def disconnect
       @db.disconnect
     end

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -4,18 +4,24 @@ require "sequel/extensions/migration"
 
 module Pliny
   class DbSupport
-    def self.run(url, options={})
-      instance = new(url, options)
+    @@logger = nil
+
+    def self.logger=(logger)
+      @@logger=logger
+    end
+
+    def self.run(url)
+      instance = new(url)
       yield instance
       instance.disconnect
     end
 
     attr_accessor :db
 
-    def initialize(url, options={})
+    def initialize(url)
       @db = Sequel.connect(url)
-      if logger = options[:logger]
-        @db.loggers << logger
+      if @@logger
+        @db.loggers << @@logger
       end
     end
 

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -1,0 +1,30 @@
+require "logger"
+require "sequel"
+require "sequel/extensions/migration"
+
+module Pliny
+  class DbSupport
+    def self.run(url, options={})
+      instance = new(url, options)
+      yield instance
+      instance.disconnect
+    end
+
+    attr_accessor :db
+
+    def initialize(url, options={})
+      @db = Sequel.connect(url)
+      if logger = options[:logger]
+        @db.loggers << logger
+      end
+    end
+
+    def migrate
+      Sequel::Migrator.apply(db, "./db/migrate")
+    end
+
+    def disconnect
+      @db.disconnect
+    end
+  end
+end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -6,12 +6,14 @@ require "uri"
 require "pliny/db_support"
 require "pliny/utils"
 
+Pliny::DbSupport.logger = Logger.new($stdout)
+
 namespace :db do
   desc "Run database migrations"
   task :migrate do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
-      Pliny::DbSupport.run(database_url, logger: Logger.new($stdout)) do |helper|
+      Pliny::DbSupport.run(database_url) do |helper|
         helper.migrate
         puts "Migrated `#{name_from_uri(database_url)}`"
       end
@@ -22,7 +24,7 @@ namespace :db do
   task :rollback do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
-      Pliny::DbSupport.run(database_url, logger: Logger.new($stdout)) do |helper|
+      Pliny::DbSupport.run(database_url) do |helper|
         helper.rollback
         puts "Rolled back `#{name_from_uri(database_url)}`"
       end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -3,6 +3,7 @@ require "sequel"
 require "sequel/extensions/migration"
 require "uri"
 
+require "pliny/db_support"
 require "pliny/utils"
 
 namespace :db do
@@ -10,12 +11,11 @@ namespace :db do
   task :migrate do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
-      db = Sequel.connect(database_url)
-      db.loggers << Logger.new($stdout)
-      Sequel::Migrator.apply(db, "./db/migrate")
-      puts "Migrated `#{name_from_uri(database_url)}`"
+      Pliny::DbSupport.run(database_url, logger: Logger.new($stdout)) do |helper|
+        helper.migrate
+        puts "Migrated `#{name_from_uri(database_url)}`"
+      end
     end
-    disconnect
   end
 
   desc "Rollback last database migration"

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -18,13 +18,19 @@ namespace :db do
     disconnect
   end
 
-  desc "Rollback the database"
+  desc "Rollback last database migration"
   task :rollback do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
       db = Sequel.connect(database_url)
       db.loggers << Logger.new($stdout)
-      Sequel::Migrator.apply(db, "./db/migrate", -1)
+      migrations = Dir["./db/migrate/*.rb"].map { |f| File.basename(f).to_i }.sort
+      current = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename].to_i
+      target = 0 # by default, rollback everything
+      if i = migrations.index(current)
+        target = migrations[i - 1] || 0
+      end
+      Sequel::Migrator.apply(db, "./db/migrate", target)
       puts "Rolled back `#{name_from_uri(database_url)}`"
     end
     disconnect

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "pliny/db_support"
 
 describe Pliny::DbSupport do
-  let(:support) { Pliny::DbSupport.new(ENV["DATABASE_URL"]) }
+  let(:support) { Pliny::DbSupport.new(ENV["TEST_DATABASE_URL"]) }
 
   before(:all) do
     @path = "/tmp/pliny-test"

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "pliny/db_support"
+
+describe Pliny::DbSupport do
+  let(:support) { Pliny::DbSupport.new(ENV["DATABASE_URL"]) }
+
+  before(:all) do
+    @db = Sequel.connect(ENV["DATABASE_URL"])
+    @path = "/tmp/pliny-test"
+  end
+
+  before(:each) do
+    @db.tables.each { |t| @db.drop_table(t) }
+    FileUtils.rm_rf(@path)
+    FileUtils.mkdir_p("#{@path}/db/migrate")
+    Dir.chdir(@path)
+  end
+
+  describe "#migrate" do
+    before do
+      File.open("#{@path}/db/migrate/#{Time.now.to_i}_create_foo.rb", "w") do |f|
+        f.puts "
+          Sequel.migration do
+            change do
+              create_table(:foo) do
+                primary_key :id
+                text        :bar
+              end
+            end
+          end
+        "
+      end
+    end
+
+    it "migrates the database" do
+      support.migrate
+      assert_equal [:foo, :schema_migrations], @db.tables.sort
+      assert_equal [:bar, :id], @db[:foo].columns.sort
+    end
+  end
+end

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -5,12 +5,11 @@ describe Pliny::DbSupport do
   let(:support) { Pliny::DbSupport.new(ENV["DATABASE_URL"]) }
 
   before(:all) do
-    @db = Sequel.connect(ENV["DATABASE_URL"])
     @path = "/tmp/pliny-test"
   end
 
   before(:each) do
-    @db.tables.each { |t| @db.drop_table(t) }
+    DB.tables.each { |t| DB.drop_table(t) }
     FileUtils.rm_rf(@path)
     FileUtils.mkdir_p("#{@path}/db/migrate")
     Dir.chdir(@path)
@@ -34,8 +33,8 @@ describe Pliny::DbSupport do
 
     it "migrates the database" do
       support.migrate
-      assert_equal [:foo, :schema_migrations], @db.tables.sort
-      assert_equal [:bar, :id], @db[:foo].columns.sort
+      assert_equal [:foo, :schema_migrations], DB.tables.sort
+      assert_equal [:bar, :id], DB[:foo].columns.sort
     end
   end
 
@@ -58,9 +57,9 @@ describe Pliny::DbSupport do
     it "reverts one migration" do
       support.migrate
       support.rollback
-      assert_equal [:first, :schema_migrations, :second], @db.tables.sort
+      assert_equal [:first, :schema_migrations, :second], DB.tables.sort
       support.rollback
-      assert_equal [:first, :schema_migrations], @db.tables.sort
+      assert_equal [:first, :schema_migrations], DB.tables.sort
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 ENV["RACK_ENV"] = "test"
 
 # have this database is available for tests
-ENV["DATABASE_URL"] ||= "postgres://localhost/pliny-test"
+ENV["DATABASE_URL"] ||= "postgres://localhost/pliny-gem-test"
 
 require "bundler"
 Bundler.require

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,12 +9,14 @@ Bundler.require
 
 require "fileutils"
 require "rack/test"
+require "sequel"
 require "sinatra/namespace"
 require "sinatra/router"
 require "timecop"
 
 require_relative "../lib/pliny"
 Pliny::Utils.require_glob("./spec/support/**/*.rb")
+DB = Sequel.connect(ENV["DATABASE_URL"])
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,13 @@
 # make sure this is set before Sinatra is required
 ENV["RACK_ENV"] = "test"
 
+# have this database is available for tests
+ENV["DATABASE_URL"] ||= "postgres://localhost/pliny-test"
+
 require "bundler"
 Bundler.require
 
+require "fileutils"
 require "rack/test"
 require "sinatra/namespace"
 require "sinatra/router"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 ENV["RACK_ENV"] = "test"
 
 # have this database is available for tests
-ENV["DATABASE_URL"] ||= "postgres://localhost/pliny-gem-test"
+ENV["TEST_DATABASE_URL"] ||= "postgres://localhost/pliny-gem-test"
 
 require "bundler"
 Bundler.require
@@ -16,7 +16,7 @@ require "timecop"
 
 require_relative "../lib/pliny"
 Pliny::Utils.require_glob("./spec/support/**/*.rb")
-DB = Sequel.connect(ENV["DATABASE_URL"])
+DB = Sequel.connect(ENV["TEST_DATABASE_URL"])
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods


### PR DESCRIPTION
Noticed `rake db:rollback` was nuking all my tables... I think this code used to work for sequential migrations (eg: `1_create_table_foo`), but wasn't adapted for timestamp based migrations.

This is quite verbose, but looking in [Sequel's source](https://github.com/jeremyevans/sequel/blob/master/lib/sequel/extensions/migration.rb) I didn't find a way to make this cleaner; thought about instantiating the actual `TimestampMigrator` but that seems like an internal class that we shouldn't rely on.