### PR TITLE
Add helper to measure metrics in logs

### DIFF
--- a/lib/pliny.rb
+++ b/lib/pliny.rb
@@ -8,6 +8,7 @@ require_relative "pliny/extensions/instruments"
 require_relative "pliny/helpers/encode"
 require_relative "pliny/helpers/params"
 require_relative "pliny/log"
+require_relative "pliny/measure"
 require_relative "pliny/request_store"
 require_relative "pliny/router"
 require_relative "pliny/utils"
@@ -19,4 +20,5 @@ require_relative "pliny/middleware/versioning"
 
 module Pliny
   extend Log
+  extend Measure
 end

--- a/lib/pliny/measure.rb
+++ b/lib/pliny/measure.rb
@@ -1,0 +1,15 @@
+module Pliny
+  module Measure
+    def measure(name, options = {})
+      start = Time.now
+      return_value = yield if block_given?
+      duration = Time.now - start
+      log({"measure##{name}": (duration * 1000).round}.merge(options))
+      return_value
+    end
+
+    def count(name, value = 1, options = {})
+      log({"count##{name}": value}.merge(options))
+    end
+  end
+end

--- a/lib/pliny/measure.rb
+++ b/lib/pliny/measure.rb
@@ -4,12 +4,12 @@ module Pliny
       start = Time.now
       return_value = yield if block_given?
       duration = Time.now - start
-      log({"measure##{name}": (duration * 1000).round}.merge(options))
+      log({"measure##{name}" => (duration * 1000).round}.merge(options))
       return_value
     end
 
     def count(name, value = 1, options = {})
-      log({"count##{name}": value}.merge(options))
+      log({"count##{name}" => value}.merge(options))
     end
   end
 end

--- a/spec/measure_spec.rb
+++ b/spec/measure_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe Pliny::Measure do
+  before do
+    @io = StringIO.new
+    Pliny.stdout = @io
+    stub(@io).print
+  end
+
+  describe '#measure' do
+    it "logs in l2met structured format" do
+      mock(@io).print "measure#request=0\n"
+      Pliny.measure('request')
+    end
+
+    it "accepts an optional hash of options for logs" do
+      mock(@io).print "measure#request=0 source=test\n"
+      Pliny.measure('request', source: 'test')
+    end
+  end
+
+  describe '#count' do
+    it "logs in l2met structured format" do
+      mock(@io).print "count#request=2\n"
+      Pliny.count('request', 2)
+    end
+
+    it "has a default value" do
+      mock(@io).print "count#request=1\n"
+      Pliny.count('request')
+    end
+
+    it "accepts an optional hash of options for logs" do
+      mock(@io).print "count#request=2 source=test\n"
+      Pliny.count('request', 2, source: 'test')
+    end
+  end
+end


### PR DESCRIPTION
This will permit to instrument code easily.
Following the l2met convention.

```
Pliny.measure(‘something.important’, source: Config.pliny_env) do
  something_important
end
#=> measure#something.important=123 source=production
```

```
Pliny.count(‘code.lines’, 1000, source: Config.pliny_env)
#=> count#code.lines=1000 source=production
```