### PR TITLE
Add console to template Procfile

### DIFF
--- a/lib/template/Procfile
+++ b/lib/template/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma --config config/puma.rb config.ru
+console: bundle exec bin/console


### PR DESCRIPTION
By default Heroku runs default `irb` when you do `heroku run console` on a Pliny app. This PR makes it actually run Pliny console.