### PR TITLE
Make Sinatra::NotFound error a warning

### DIFF
--- a/lib/template/config/initializers/rollbar.rb
+++ b/lib/template/config/initializers/rollbar.rb
@@ -2,5 +2,6 @@ Rollbar.configure do |config|
   config.enabled = ENV.has_key?('ROLLBAR_ACCESS_TOKEN')
   config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
   config.use_sucker_punch
+  config.exception_level_filters.merge! "Sinatra::NotFound" => "warning"
 end
 


### PR DESCRIPTION
Right now Rollbar reports this as a critical error by default.