### PR TITLE
Change mount to run on endpoint generator

### DIFF
--- a/lib/pliny/commands/generator/endpoint.rb
+++ b/lib/pliny/commands/generator/endpoint.rb
@@ -13,7 +13,7 @@ module Pliny::Commands
                         url_path: url_path)
         display "created endpoint file #{endpoint}"
         display 'add the following to lib/routes.rb:'
-        display "  mount Endpoints::#{plural_class_name}"
+        display "  run Endpoints::#{plural_class_name}"
       end
 
       def create_test


### PR DESCRIPTION
Is the right command on endpoint generator `run` instead `mount`? 

The default template uses `run`, but the display message ask to add `mount`.