### PR TITLE
Moar db:rollback fixes

### DIFF
--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -30,6 +30,8 @@ module Pliny
     end
 
     def rollback
+      return unless db.tables.include?(:schema_migrations)
+
       migrations = Dir["./db/migrate/*.rb"].map { |f| File.basename(f).to_i }.sort
       current    = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename].to_i
       target     = 0 # by default, rollback everything

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -25,17 +25,17 @@ module Pliny
       end
     end
 
-    def migrate
-      Sequel::Migrator.apply(db, "./db/migrate")
+    def migrate(target=nil)
+      Sequel::Migrator.apply(db, "./db/migrate", target)
     end
 
     def rollback
       return unless db.tables.include?(:schema_migrations)
+      return unless current = db[:schema_migrations].order(Sequel.desc(:filename)).first
 
       migrations = Dir["./db/migrate/*.rb"].map { |f| File.basename(f).to_i }.sort
-      current    = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename].to_i
       target     = 0 # by default, rollback everything
-      index      = migrations.index(current)
+      index      = migrations.index(current[:filename].to_i)
       if index > 0
         target = migrations[index - 1]
       end

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -31,10 +31,11 @@ module Pliny
 
     def rollback
       migrations = Dir["./db/migrate/*.rb"].map { |f| File.basename(f).to_i }.sort
-      current = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename].to_i
-      target = 0 # by default, rollback everything
-      if i = migrations.index(current)
-        target = migrations[i - 1] || 0
+      current    = db[:schema_migrations].order(Sequel.desc(:filename)).first[:filename].to_i
+      target     = 0 # by default, rollback everything
+      index      = migrations.index(current)
+      if index > 0
+        target = migrations[index - 1]
       end
       Sequel::Migrator.apply(db, "./db/migrate", target)
     end

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -64,5 +64,9 @@ describe Pliny::DbSupport do
       support.rollback
       assert_equal [:schema_migrations], DB.tables.sort
     end
+
+    it "handle empty databases" do
+      support.rollback # noop
+    end
   end
 end

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -41,23 +41,17 @@ describe Pliny::DbSupport do
   describe "#rollback" do
     before do
       @t = Time.now
-      File.open("#{@path}/db/migrate/#{(@t-3).to_i}_first.rb", "w") do |f|
+      File.open("#{@path}/db/migrate/#{(@t-2).to_i}_first.rb", "w") do |f|
         f.puts "Sequel.migration { change { create_table(:first) } }"
       end
 
-      File.open("#{@path}/db/migrate/#{(@t-2).to_i}_second.rb", "w") do |f|
+      File.open("#{@path}/db/migrate/#{(@t-1).to_i}_second.rb", "w") do |f|
         f.puts "Sequel.migration { change { create_table(:second) } }"
-      end
-
-      File.open("#{@path}/db/migrate/#{(@t-1).to_i}_third.rb", "w") do |f|
-        f.puts "Sequel.migration { change { create_table(:third) } }"
       end
     end
 
     it "reverts migrations" do
       support.migrate
-      assert_equal [:first, :schema_migrations, :second, :third], DB.tables.sort
-      support.rollback
       assert_equal [:first, :schema_migrations, :second], DB.tables.sort
       support.rollback
       assert_equal [:first, :schema_migrations], DB.tables.sort
@@ -70,7 +64,7 @@ describe Pliny::DbSupport do
     end
 
     it "handles databases not migrated (schema_migrations is empty)" do
-      support.migrate (@t-3).to_i
+      support.migrate (@t-2).to_i
       support.rollback # destroy table, leave schema_migrations
       support.rollback # should noop
     end

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -40,16 +40,16 @@ describe Pliny::DbSupport do
 
   describe "#rollback" do
     before do
-      t = Time.now
-      File.open("#{@path}/db/migrate/#{(t-3).to_i}_first.rb", "w") do |f|
+      @t = Time.now
+      File.open("#{@path}/db/migrate/#{(@t-3).to_i}_first.rb", "w") do |f|
         f.puts "Sequel.migration { change { create_table(:first) } }"
       end
 
-      File.open("#{@path}/db/migrate/#{(t-2).to_i}_second.rb", "w") do |f|
+      File.open("#{@path}/db/migrate/#{(@t-2).to_i}_second.rb", "w") do |f|
         f.puts "Sequel.migration { change { create_table(:second) } }"
       end
 
-      File.open("#{@path}/db/migrate/#{(t-1).to_i}_third.rb", "w") do |f|
+      File.open("#{@path}/db/migrate/#{(@t-1).to_i}_third.rb", "w") do |f|
         f.puts "Sequel.migration { change { create_table(:third) } }"
       end
     end
@@ -65,8 +65,14 @@ describe Pliny::DbSupport do
       assert_equal [:schema_migrations], DB.tables.sort
     end
 
-    it "handle empty databases" do
+    it "handle blank databases (no schema_migrations table)" do
       support.rollback # noop
+    end
+
+    it "handles databases not migrated (schema_migrations is empty)" do
+      support.migrate (@t-3).to_i
+      support.rollback # destroy table, leave schema_migrations
+      support.rollback # should noop
     end
   end
 end

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -54,12 +54,15 @@ describe Pliny::DbSupport do
       end
     end
 
-    it "reverts one migration" do
+    it "reverts migrations" do
       support.migrate
+      assert_equal [:first, :schema_migrations, :second, :third], DB.tables.sort
       support.rollback
       assert_equal [:first, :schema_migrations, :second], DB.tables.sort
       support.rollback
       assert_equal [:first, :schema_migrations], DB.tables.sort
+      support.rollback
+      assert_equal [:schema_migrations], DB.tables.sort
     end
   end
 end


### PR DESCRIPTION
- Fix issue rolling back the first migration
- Do not raise when database is empty
- Do not raise when database doesn't have any migrations applied

fix #167