### PR TITLE
drop db:nuke and reset tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ Pliny comes with several rake tasks:
 rake db:create        # Create the database
 rake db:drop          # Drop the database
 rake db:migrate       # Run database migrations
-rake db:nuke          # Nuke the database (drop all tables)
-rake db:reset         # Reset the database
 rake db:rollback      # Rollback the database
 rake db:schema:dump   # Dump the database schema
 rake db:schema:load   # Load the database schema

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -31,18 +31,6 @@ namespace :db do
     end
   end
 
-  desc "Nuke the database (drop all tables)"
-  task :nuke do
-    database_urls.each do |database_url|
-      db = Sequel.connect(database_url)
-      db.tables.each do |table|
-        db.run(%{DROP TABLE "#{table}" CASCADE})
-      end
-      puts "Nuked `#{name_from_uri(database_url)}`"
-    end
-    disconnect
-  end
-
   desc "Seed the database with data"
   task :seed do
     if File.exist?('./db/seeds.rb')
@@ -53,9 +41,6 @@ namespace :db do
       disconnect
     end
   end
-
-  desc "Reset the database"
-  task :reset => [:nuke, :migrate, :seed]
 
   desc "Create the database"
   task :create do


### PR DESCRIPTION
Nuke is delicate because dropping tables alone is not guaranteed
to clean it all up (eg: user-defined types). Instead we're just
going to recommend users to drop/recreate the entire database.

With this in mind db:reset becomes just setup.