### PR TITLE
Make migration generator name arg more flexible

### DIFF
--- a/lib/pliny/commands/generator.rb
+++ b/lib/pliny/commands/generator.rb
@@ -23,8 +23,8 @@ module Pliny::Commands
       md.create_test
     end
 
-    desc 'migration NAME', 'Generates a migration'
-    def migration(name)
+    desc 'migration [NAME]', 'Generates a migration'
+    def migration(*name)
       require_relative 'generator/migration'
 
       mg = Migration.new(name, options)

--- a/lib/pliny/commands/generator/migration.rb
+++ b/lib/pliny/commands/generator/migration.rb
@@ -3,10 +3,23 @@ require_relative 'base'
 module Pliny::Commands
   class Generator
     class Migration < Base
+      def initialize(name, options = {}, stream = $stdout)
+        super
+        @name = normalize_name(name)
+      end
+
       def create
         migration = "./db/migrate/#{Time.now.to_i}_#{name}.rb"
         write_template('migration.erb', migration)
         display "created migration #{migration}"
+      end
+
+      private
+
+      def normalize_name(name)
+        Array(name).map(&:underscore)
+                   .map { |n| n.tr(' ', '_') }
+                   .join('_')
       end
     end
   end

--- a/spec/commands/generator/migration_spec.rb
+++ b/spec/commands/generator/migration_spec.rb
@@ -2,34 +2,18 @@ require 'pliny/commands/generator'
 require 'pliny/commands/generator/migration'
 require 'spec_helper'
 
-describe Pliny::Commands::Generator::Base do
-  subject { Pliny::Commands::Generator::Migration.new(migration_name, {}, StringIO.new) }
-
+describe Pliny::Commands::Generator::Migration do
   describe '#name' do
-    shared_examples 'a migration name' do
-      it 'generates a snakecase name' do
-        assert_equal 'add_column_foo_to_barz', subject.name
+    it 'generates a migration name given differents argument formats' do
+      [
+        %w(add column foo to barz),
+        'add column foo to barz',
+        'add_column_foo_to_barz',
+        'AddColumnFooToBarz'
+      ].each do |argument|
+        actual = described_class.new(argument, {}, StringIO.new).name
+        assert_equal 'add_column_foo_to_barz', actual
       end
-    end
-
-    context 'given array of args' do
-      let(:migration_name) { %w(add column foo to barz) }
-      it_behaves_like 'a migration name'
-    end
-
-    context 'given string separated by whitepsaces' do
-      let(:migration_name) { 'add column foo to barz' }
-      it_behaves_like 'a migration name'
-    end
-
-    context 'given a snakecase name' do
-      let(:migration_name) { 'add_column_foo_to_barz' }
-      it_behaves_like 'a migration name'
-    end
-
-    context 'given a camelcase name' do
-      let(:migration_name) { 'AddColumnFooToBarz' }
-      it_behaves_like 'a migration name'
     end
   end
 end

--- a/spec/commands/generator/migration_spec.rb
+++ b/spec/commands/generator/migration_spec.rb
@@ -1,0 +1,35 @@
+require 'pliny/commands/generator'
+require 'pliny/commands/generator/migration'
+require 'spec_helper'
+
+describe Pliny::Commands::Generator::Base do
+  subject { Pliny::Commands::Generator::Migration.new(migration_name, {}, StringIO.new) }
+
+  describe '#name' do
+    shared_examples 'a migration name' do
+      it 'generates a snakecase name' do
+        assert_equal 'add_column_foo_to_barz', subject.name
+      end
+    end
+
+    context 'given array of args' do
+      let(:migration_name) { %w(add column foo to barz) }
+      it_behaves_like 'a migration name'
+    end
+
+    context 'given string separated by whitepsaces' do
+      let(:migration_name) { 'add column foo to barz' }
+      it_behaves_like 'a migration name'
+    end
+
+    context 'given a snakecase name' do
+      let(:migration_name) { 'add_column_foo_to_barz' }
+      it_behaves_like 'a migration name'
+    end
+
+    context 'given a camelcase name' do
+      let(:migration_name) { 'AddColumnFooToBarz' }
+      it_behaves_like 'a migration name'
+    end
+  end
+end


### PR DESCRIPTION
Migration names are usually big and this makes it easier to write. This might applies to the other generators, I'm suggesting it at least for the migration due its usual name length

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/interagent/pliny/172)
<!-- Reviewable:end -->
