### PR TITLE
Set updated_at on model creation

### DIFF
--- a/lib/pliny/templates/model.erb
+++ b/lib/pliny/templates/model.erb
@@ -1,5 +1,5 @@
 class <%= singular_class_name %> < Sequel::Model
-  plugin :timestamps
+  plugin :timestamps, update_on_create: true
 <% if paranoid %>
   plugin :paranoid
 <% end %>

--- a/lib/pliny/templates/model_migration.erb
+++ b/lib/pliny/templates/model_migration.erb
@@ -6,7 +6,7 @@ Sequel.migration do
 <% if paranoid %>
       timestamptz  :deleted_at
 <% end %>
-      timestamptz  :updated_at
+      timestamptz  :updated_at, default: Sequel.function(:now), null: false
     end
   end
 end


### PR DESCRIPTION
The default behavior of Sequel is to leave `updated_at` as `null`. This causes some issues when sorting models by `updated_at`. This is also to be consistent with ActiveRecord and simplify JSON schemas.