### PR TITLE
Update README blurb for sequel-pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And gems/helpers to tie these together and support operations:
 - [Request IDs](lib/pliny/middleware/request_id.rb)
 - [RequestStore](http://brandur.org/antipatterns), thread safe option to store data with the current request
 - [Sequel](http://sequel.jeremyevans.net/) for ORM
-- [Sequel-PG](https://github.com/jeremyevans/sequel_pg) because we don't like mysql
+- [Sequel-PG](https://github.com/jeremyevans/sequel_pg) to talk to the world's most advanced open source database
 - [Versioning](lib/pliny/middleware/versioning.rb) to allow versioning your API in the HTTP Accept header
 
 ## Getting started


### PR DESCRIPTION
The current blurb is a cute joke, but it's not going to sway anyone and the jab is a little immature. The blurb I'm suggesting is one [Postgres has been using for years](http://www.postgresql.org/), but it's a little stodgy, so I'm open to other suggestions. Mostly I'd like to see the current wording go.