### PR TITLE
Deployment notes about initializing the DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ $ bundle install
 $ rake
 ```
 
+## Deployment
+
+Before a Pliny app can use the database, the schema must be loaded & then migrated.
+
+Generally after your initial deployment, execute `rake db:schema:load db:migrate` in the environment's console.
+
+On Heroku specifically:
+```
+$ git push heroku master
+$ heroku run rake db:schema:load db:migrate
+```
+
 ## Meta
 
 Created by Brandur Leach and Pedro Belo.


### PR DESCRIPTION
Tried running `heroku run bin/setup` but fails with the error:

    Sequel::DatabaseConnectionError: PG::ConnectionBad: FATAL:  permission denied for database "postgres"
    DETAIL:  User does not have CONNECT privilege.
    /app/vendor/bundle/ruby/2.2.0/gems/sequel-4.24.0/lib/sequel/adapters/postgres.rb:237:in `initialize'

Found this solution in [an old issue](https://github.com/interagent/pliny/issues/63#issuecomment-84380506).