### PR TITLE
Return an id and message in body when 404 in json.

### DIFF
--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -20,7 +20,7 @@ module Endpoints
     error Sinatra::NotFound do
       content_type :json
       status 404
-      "{}"
+      { id: "not_found", message: "Resource not found" }.to_json
     end
   end
 end


### PR DESCRIPTION
All other errors return something with `id` and `message`.
This is just uniformising the behavior there.