### PR TITLE
Make existing db check in rake db:create explicit

### DIFF
--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -6,6 +6,12 @@ module Pliny
   class DbSupport
     @@logger = nil
 
+    def self.admin_url(database_url)
+      uri = URI.parse(database_url)
+      uri.path = "/postgres"
+      uri.to_s
+    end
+
     def self.logger=(logger)
       @@logger=logger
     end

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -26,12 +26,13 @@ module Pliny
       end
     end
 
+    def exists?(name)
+      res = db.fetch("SELECT 1 FROM pg_database WHERE datname = ?", name)
+      return res.count > 0
+    end
+
     def create(name)
       db.run(%{CREATE DATABASE "#{name}"})
-      return true
-    rescue Sequel::DatabaseError
-      raise unless $!.message =~ /already exists/
-      return false
     end
 
     def migrate(target=nil)

--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -10,6 +10,15 @@ module Pliny
       uri.to_s
     end
 
+    def self.setup?(database_url)
+      @db = Sequel.connect(database_url)
+      @db.test_connection
+      @db.disconnect
+      return true
+    rescue Sequel::DatabaseConnectionError
+      return false
+    end
+
     def self.run(url, sequel_log_io=StringIO.new)
       logger = Logger.new(sequel_log_io)
       instance = new(url, logger)

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -6,14 +6,12 @@ require "uri"
 require "pliny/db_support"
 require "pliny/utils"
 
-Pliny::DbSupport.logger = Logger.new($stdout)
-
 namespace :db do
   desc "Run database migrations"
   task :migrate do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
-      Pliny::DbSupport.run(database_url) do |helper|
+      Pliny::DbSupport.run(database_url, $stdout) do |helper|
         helper.migrate
         puts "Migrated `#{name_from_uri(database_url)}`"
       end
@@ -24,7 +22,7 @@ namespace :db do
   task :rollback do
     next if Dir["./db/migrate/*.rb"].empty?
     database_urls.each do |database_url|
-      Pliny::DbSupport.run(database_url) do |helper|
+      Pliny::DbSupport.run(database_url, $stdout) do |helper|
         helper.rollback
         puts "Rolled back `#{name_from_uri(database_url)}`"
       end
@@ -46,13 +44,13 @@ namespace :db do
   task :create do
     database_urls.each do |database_url|
       admin_url = Pliny::DbSupport.admin_url(database_url)
-      db = Sequel.connect(admin_url)
-      name = name_from_uri(database_url)
-      begin
-        db.run(%{CREATE DATABASE "#{name}"})
-        puts "Created `#{name}`"
-      rescue Sequel::DatabaseError
-        raise unless $!.message =~ /already exists/
+      Pliny::DbSupport.run(admin_url) do |helper|
+        db_name = name_from_uri(database_url)
+        if helper.create(db_name)
+          puts "Created `#{db_name}`"
+        else
+          puts "Skipped `#{db_name}`"
+        end
       end
     end
     disconnect

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -43,12 +43,12 @@ namespace :db do
   desc "Create the database"
   task :create do
     database_urls.each do |database_url|
-      admin_url = Pliny::DbSupport.admin_url(database_url)
-      Pliny::DbSupport.run(admin_url) do |helper|
-        db_name = name_from_uri(database_url)
-        if helper.exists?(db_name)
-          puts "Skipped `#{db_name}` already exists"
-        else
+      db_name = name_from_uri(database_url)
+      if Pliny::DbSupport.setup?(database_url)
+        puts "Skipping `#{db_name}`, already exists"
+      else
+        admin_url = Pliny::DbSupport.admin_url(database_url)
+        Pliny::DbSupport.run(admin_url) do |helper|
           helper.create(db_name)
           puts "Created `#{db_name}`"
         end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -46,10 +46,11 @@ namespace :db do
       admin_url = Pliny::DbSupport.admin_url(database_url)
       Pliny::DbSupport.run(admin_url) do |helper|
         db_name = name_from_uri(database_url)
-        if helper.create(db_name)
-          puts "Created `#{db_name}`"
+        if helper.exists?(db_name)
+          puts "Skipped `#{db_name}` already exists"
         else
-          puts "Skipped `#{db_name}`"
+          helper.create(db_name)
+          puts "Created `#{db_name}`"
         end
       end
     end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -46,15 +46,13 @@ namespace :db do
   task :create do
     database_urls.each do |database_url|
       db = Sequel.connect("#{postgres_location_from_uri(database_url)}/postgres")
-      exists = false
       name = name_from_uri(database_url)
       begin
         db.run(%{CREATE DATABASE "#{name}"})
+        puts "Created `#{name}`"
       rescue Sequel::DatabaseError
         raise unless $!.message =~ /already exists/
-        exists = true
       end
-      puts "Created `#{name}`" if !exists
     end
     disconnect
   end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -45,7 +45,8 @@ namespace :db do
   desc "Create the database"
   task :create do
     database_urls.each do |database_url|
-      db = Sequel.connect("#{postgres_location_from_uri(database_url)}/postgres")
+      admin_url = Pliny::DbSupport.admin_url(database_url)
+      db = Sequel.connect(admin_url)
       name = name_from_uri(database_url)
       begin
         db.run(%{CREATE DATABASE "#{name}"})
@@ -60,7 +61,8 @@ namespace :db do
   desc "Drop the database"
   task :drop do
     database_urls.each do |database_url|
-      db = Sequel.connect("#{postgres_location_from_uri(database_url)}/postgres")
+      admin_url = Pliny::DbSupport.admin_url(database_url)
+      db = Sequel.connect(admin_url)
       name = name_from_uri(database_url)
       db.run(%{DROP DATABASE IF EXISTS "#{name}"})
       puts "Dropped `#{name}`"
@@ -143,11 +145,5 @@ namespace :db do
 
   def name_from_uri(uri)
     URI.parse(uri).path[1..-1]
-  end
-
-  def postgres_location_from_uri(uri)
-    p = URI.parse(uri)
-    p.path = ""
-    p.to_s
   end
 end

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -24,11 +24,10 @@ describe Pliny::DbSupport do
     end
   end
 
-  describe "#exists?" do
-    it "checks if the database already exists" do
-      my_db_name = URI.parse(url).path.sub(/^\//, '')
-      assert_equal true, support.exists?(my_db_name)
-      assert_equal false, support.exists?("a-db-that-doesnt-exist")
+  describe ".setup?" do
+    it "checks if the database is responsive" do
+      assert_equal true, Pliny::DbSupport.setup?(url)
+      assert_equal false, Pliny::DbSupport.setup?("postgres://localhost/does-not-exist")
     end
   end
 

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -24,6 +24,14 @@ describe Pliny::DbSupport do
     end
   end
 
+  describe "#exists?" do
+    it "checks if the database already exists" do
+      my_db_name = URI.parse(@url).path.sub(/^\//, '')
+      assert_equal true, support.exists?(my_db_name)
+      assert_equal false, support.exists?("a-db-that-doesnt-exist")
+    end
+  end
+
   describe "#migrate" do
     before do
       File.open("#{@path}/db/migrate/#{Time.now.to_i}_create_foo.rb", "w") do |f|

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -15,6 +15,13 @@ describe Pliny::DbSupport do
     Dir.chdir(@path)
   end
 
+  describe ".admin_url" do
+    it "connects to the postgres system's db" do
+      assert_equal "postgres://1.2.3.4/postgres",
+        Pliny::DbSupport.admin_url("postgres://1.2.3.4/my-db")
+    end
+  end
+
   describe "#migrate" do
     before do
       File.open("#{@path}/db/migrate/#{Time.now.to_i}_create_foo.rb", "w") do |f|

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -24,22 +24,6 @@ describe Pliny::DbSupport do
     end
   end
 
-  describe "#create" do
-    it "creates a new postgres database" do
-      @url = Pliny::DbSupport.admin_url(@url)
-      db_name = "pliny_test_#{Process.pid}"
-      begin
-        assert support.create(db_name)
-        uri = URI.parse(@url)
-        uri.path = "/#{db_name}"
-        test_db = Sequel.connect(uri.to_s)
-        assert_equal 1, test_db.fetch("SELECT 1 AS f").first[:f]
-      ensure
-        support.db.fetch "DROP DATABASE ?", db_name
-      end
-    end
-  end
-
   describe "#migrate" do
     before do
       File.open("#{@path}/db/migrate/#{Time.now.to_i}_create_foo.rb", "w") do |f|

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -29,7 +29,7 @@ describe Pliny::DbSupport do
       @url = Pliny::DbSupport.admin_url(@url)
       db_name = "pliny_test_#{Process.pid}"
       begin
-        support.create(db_name)
+        assert support.create(db_name)
         uri = URI.parse(@url)
         uri.path = "/#{db_name}"
         test_db = Sequel.connect(uri.to_s)

--- a/spec/db_support_spec.rb
+++ b/spec/db_support_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "pliny/db_support"
 
 describe Pliny::DbSupport do
+  let(:url) { ENV["TEST_DATABASE_URL"] }
   let(:logger) { Logger.new(StringIO.new) }
-  let(:support) { Pliny::DbSupport.new(@url, logger) }
+  let(:support) { Pliny::DbSupport.new(url, logger) }
 
   before do
-    @url = ENV["TEST_DATABASE_URL"]
     @path = "/tmp/pliny-test"
   end
 
@@ -26,7 +26,7 @@ describe Pliny::DbSupport do
 
   describe "#exists?" do
     it "checks if the database already exists" do
-      my_db_name = URI.parse(@url).path.sub(/^\//, '')
+      my_db_name = URI.parse(url).path.sub(/^\//, '')
       assert_equal true, support.exists?(my_db_name)
       assert_equal false, support.exists?("a-db-that-doesnt-exist")
     end


### PR DESCRIPTION
This way Pliny will also avoid trying to create a db when it doesn't have permissions.

Fix #181