### PR TITLE
Do not render status with the error representation

### DIFF
--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -5,7 +5,7 @@ module Pliny
 
       def self.render(error)
         headers = { "Content-Type" => "application/json; charset=utf-8" }
-        data = { id: error.id, message: error.message, status: error.status }
+        data = { id: error.id, message: error.message }
         [error.status, headers, [MultiJson.encode(data)]]
       end
 

--- a/spec/middleware/rescue_errors_spec.rb
+++ b/spec/middleware/rescue_errors_spec.rb
@@ -24,7 +24,6 @@ describe Pliny::Middleware::RescueErrors do
     error_json = MultiJson.decode(last_response.body)
     assert_equal "service_unavailable", error_json["id"]
     assert_equal "Service unavailable.", error_json["message"]
-    assert_equal 503, error_json["status"]
   end
 
   it "intercepts exceptions and renders" do
@@ -34,7 +33,6 @@ describe Pliny::Middleware::RescueErrors do
     error_json = MultiJson.decode(last_response.body)
     assert_equal "internal_server_error", error_json["id"]
     assert_equal "Internal server error.", error_json["message"]
-    assert_equal 500, error_json["status"]
   end
 
   it "raises given the raise option" do


### PR DESCRIPTION
That's already in the http status. rendering again is inconsistent
(there's no `status: 200` for successful responses), and just makes
the line between response data and metadata more blur.

Thoughts?