### PR TITLE
bridge Sinatra::NotFound to corresponding Pliny::Error

### DIFF
--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -18,9 +18,7 @@ module Endpoints
     end
 
     error Sinatra::NotFound do
-      content_type :json
-      status 404
-      { id: "not_found", message: "Resource not found" }.to_json
+      raise Pliny::Errors::NotFound
     end
   end
 end


### PR DESCRIPTION
This way we're reusing the error serialization and handling defined elsewhere.
