### PR TITLE
Add array type for config

### DIFF
--- a/lib/pliny/config_helpers.rb
+++ b/lib/pliny/config_helpers.rb
@@ -35,6 +35,10 @@ module Pliny
       ->(v) { v.to_sym }
     end
 
+    def array
+      ->(v) { v.split(",") }
+    end
+
     private
 
     def cast(value, method)

--- a/lib/pliny/config_helpers.rb
+++ b/lib/pliny/config_helpers.rb
@@ -35,8 +35,18 @@ module Pliny
       ->(v) { v.to_sym }
     end
 
-    def array
-      ->(v) { v.split(",") }
+    # optional :accronyms, array(string)
+    # => ['a', 'b']
+    # optional :numbers, array(int)
+    # => [1, 2]
+    # optional :notype, array
+    # => ['a', 'b']
+    def array(method = nil)
+      -> (v) do
+        if v
+          v.split(",").map{|a| cast(a, method) }
+        end
+      end
     end
 
     private


### PR DESCRIPTION
This will add the possibility to get an array of string to the config

```
ACRONYMS=lol, rofl, trololol
```

```
optional :acronyms, array

#=> ["lol", "rofl", "trololol"]
```

```
optional :random_numbers, array(int)

#=> [1, 2, 3]
```