### PR TITLE
More strict args in pliny-generate

### DIFF
--- a/lib/pliny/commands/generator.rb
+++ b/lib/pliny/commands/generator.rb
@@ -3,9 +3,9 @@ require 'thor'
 
 module Pliny::Commands
   class Generator < Thor
-    desc 'endpoint [NAME]', 'Generates an endpoint'
+    desc 'endpoint NAME', 'Generates an endpoint'
     method_option :scaffold, type: :boolean, default: false, hide: true
-    def endpoint(*name)
+    def endpoint(name)
       require_relative 'generator/endpoint'
 
       ep = Endpoint.new(name, options)
@@ -14,8 +14,8 @@ module Pliny::Commands
       ep.create_acceptance_test
     end
 
-    desc 'mediator [NAME]', 'Generates a mediator'
-    def mediator(*name)
+    desc 'mediator NAME', 'Generates a mediator'
+    def mediator(name)
       require_relative 'generator/mediator'
 
       md = Mediator.new(name, options)
@@ -23,17 +23,17 @@ module Pliny::Commands
       md.create_test
     end
 
-    desc 'migration [NAME]', 'Generates a migration'
-    def migration(*name)
+    desc 'migration NAME', 'Generates a migration'
+    def migration(name)
       require_relative 'generator/migration'
 
       mg = Migration.new(name, options)
       mg.create
     end
 
-    desc 'model [NAME]', 'Generates a model'
+    desc 'model NAME', 'Generates a model'
     method_option :paranoid, type: :boolean, default: false, desc: 'adds paranoid support to model'
-    def model(*name)
+    def model(name)
       require_relative 'generator/model'
 
       md = Model.new(name, options)
@@ -42,18 +42,18 @@ module Pliny::Commands
       md.create_test
     end
 
-    desc 'scaffold [NAME]', 'Generates a scaffold of endpoint, model, schema and serializer'
+    desc 'scaffold NAME', 'Generates a scaffold of endpoint, model, schema and serializer'
     method_option :paranoid, type: :boolean, default: false, desc: 'adds paranoid support to model'
     method_option :scaffold, type: :boolean, default: true, hide: true
-    def scaffold(*name)
-      endpoint(*name)
-      model(*name)
-      schema(*name)
-      serializer(*name)
+    def scaffold(name)
+      endpoint(name)
+      model(name)
+      schema(name)
+      serializer(name)
     end
 
-    desc 'schema [NAME]', 'Generates a schema'
-    def schema(*name)
+    desc 'schema NAME', 'Generates a schema'
+    def schema(name)
       require_relative 'generator/schema'
 
       sc = Schema.new(name, options)
@@ -62,7 +62,7 @@ module Pliny::Commands
     end
 
     desc 'serializer [NAME]', 'Generates a serializer'
-    def serializer(*name)
+    def serializer(name)
       require_relative 'generator/serializer'
 
       se = Serializer.new(name, options)

--- a/lib/pliny/commands/generator/base.rb
+++ b/lib/pliny/commands/generator/base.rb
@@ -62,9 +62,7 @@ module Pliny::Commands
       private
 
       def normalize_name(name)
-        Array(name).map(&:underscore)
-                   .map { |n| n.tr(' ', '_') }
-                   .join('_')
+        name.underscore.tr(' ', '_')
       end
     end
   end

--- a/spec/commands/generator/base_spec.rb
+++ b/spec/commands/generator/base_spec.rb
@@ -10,7 +10,6 @@ describe Pliny::Commands::Generator::Base do
   describe '#name' do
     it 'generates a normalized name given differents argument formats' do
       [
-        %w(resource history),
         'resource history',
         'resource-history',
         'resource_history',


### PR DESCRIPTION
Looking now I think we should not take something like `pliny-generate endpoint my endpoint`.

Handling spaces is convenient, but users should escape that in their shell or opt parsing can get pretty hectic. So `pliny-generate endpoint 'my endpoint'` instead.

See #177. /cc @DyegoCosta

Fix #189