### PR TITLE
Improve pliny-new command error handling and usage info

### DIFF
--- a/bin/pliny-new
+++ b/bin/pliny-new
@@ -3,10 +3,19 @@
 require "optparse"
 require_relative '../lib/pliny/commands/creator'
 
-ARGV.options do |options|
+OptionParser.new do |options|
   opts = {}
+  options.banner = "Usage: pliny-new app-name [options]"
 
-  options.parse!
-
-  Pliny::Commands::Creator.run(ARGV.dup, opts)
+  begin
+    options.parse!
+    if ARGV.empty?
+      puts options.banner
+    else
+      Pliny::Commands::Creator.run(ARGV.dup, opts)
+    end
+  rescue OptionParser::InvalidOption => e
+    puts e
+    puts options.banner
+  end
 end


### PR DESCRIPTION
I saw that when you ran the generator without arguments, something bad happened:

```
$ pliny-new
/Users/Papipo/.rvm/gems/ruby-2.2.1/gems/pliny-0.10.0/lib/pliny/commands/creator.rb:63:in `initialize': no implicit conversion of nil into String (TypeError)
```

So I have just fixed that and added handling of unknown flags (anyone at the moment).