### PR TITLE
Run test database migrations if schema is outdated

### DIFF
--- a/lib/template/spec/spec_helper.rb
+++ b/lib/template/spec/spec_helper.rb
@@ -31,6 +31,10 @@ Dotenv.load('.env.test')
 
 require_relative "../lib/initializer"
 
+unless Sequel::Migrator.is_current?(Sequel::Model.db, 'db/migrate')
+  Sequel::Migrator.run(Sequel::Model.db, 'db/migrate')
+end
+
 # pull in test initializers
 Pliny::Utils.require_glob("#{Config.root}/spec/support/**/*.rb")
 


### PR DESCRIPTION
Check if latest migrations were applied before running the test suite.
Apply migrations if schema is outdated.

Resolves #197

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/interagent/pliny/199)

<!-- Reviewable:end -->
