### PR TITLE
Fix loading of rack-timeout

### DIFF
--- a/lib/pliny.rb
+++ b/lib/pliny.rb
@@ -1,5 +1,5 @@
 require "multi_json"
-require "rack/timeout"
+require "rack-timeout"
 require "sinatra/base"
 
 require_relative "pliny/version"

--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport",  "~> 4.1",  ">= 4.1.0"
   gem.add_dependency "multi_json",     "~> 1.9",  ">= 1.9.3"
   gem.add_dependency "prmd",           "~> 0.7.0"
-  gem.add_dependency "rack-timeout",   "~> 0.2",  ">= 0.2.3"
+  gem.add_dependency "rack-timeout",   "~> 0.3",  ">= 0.3.1"
   gem.add_dependency "sinatra",        "~> 1.4",  ">= 1.4.5"
   gem.add_dependency "http_accept",    "~> 0.1",  ">= 0.1.5"
   gem.add_dependency "sinatra-router", "~> 0.2",  ">= 0.2.3"


### PR DESCRIPTION
As of https://github.com/heroku/rack-timeout/commit/6e82c2760723a76f8cf705de6c8d2f588913d94e you must required 'rack-timeout' rather than 'rack/timeout'

Fixes interagent/pliny#207