### PR TITLE
Add db creation to development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Run tests:
 
 ```
 $ bundle install
+$ createdb pliny-gem-test
 $ rake
 ```
 


### PR DESCRIPTION
Otherwise, running `rake` exits because the database doesn't exist yet