### PR TITLE
Set content-type lazily

### DIFF
--- a/lib/pliny/helpers/encode.rb
+++ b/lib/pliny/helpers/encode.rb
@@ -1,6 +1,7 @@
 module Pliny::Helpers
   module Encode
     def encode(object)
+      content_type :json, charset: 'utf-8'
       MultiJson.encode(object, pretty: params[:pretty] == 'true' || Config.pretty_json)
     end
   end

--- a/lib/pliny/templates/endpoint.erb
+++ b/lib/pliny/templates/endpoint.erb
@@ -1,10 +1,6 @@
 module Endpoints
   class <%= plural_class_name %> < Base
     namespace "<%= url_path %>" do
-      before do
-        content_type :json, charset: 'utf-8'
-      end
-
       get do
         encode []
       end

--- a/lib/pliny/templates/endpoint_scaffold.erb
+++ b/lib/pliny/templates/endpoint_scaffold.erb
@@ -1,10 +1,6 @@
 module Endpoints
   class <%= plural_class_name %> < Base
     namespace "<%= url_path %>" do
-      before do
-        content_type :json, charset: 'utf-8'
-      end
-
       get do
         encode serialize(<%= singular_class_name %>.all)
       end

--- a/spec/helpers/encode_spec.rb
+++ b/spec/helpers/encode_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe Pliny::Helpers::Encode do
+  def app
+    Sinatra.new do
+      helpers Pliny::Helpers::Encode
+      post "/" do
+        encode(params)
+      end
+    end
+  end
+
+  before do
+    stub(Config).pretty_json { false }
+  end
+
+  it "sets the Content-Type" do
+    post "/"
+    assert_equal "application/json;charset=utf-8",
+      last_response.headers["Content-Type"]
+  end
+
+  it "encodes as json" do
+    payload = { "foo" => "bar" }
+    post "/", payload
+    assert_equal MultiJson.encode(payload), last_response.body
+  end
+
+  it "encodes in pretty mode when pretty=true" do
+    payload = { "foo" => "bar", "pretty" => "true" }
+    post "/", payload
+    assert_equal MultiJson.encode(payload, pretty: true), last_response.body
+  end
+
+  it "encodes in pretty mode when set by config" do
+    stub(Config).pretty_json { true }
+    payload = { "foo" => "bar" }
+    post "/", payload
+    assert_equal MultiJson.encode(payload, pretty: true), last_response.body
+  end
+end


### PR DESCRIPTION
Makes endpoints leaner, and helps avoid weird issues with rack-protection:
https://github.com/sinatra/sinatra/issues/518