### PR TITLE
Refactor errors

### DIFF
--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -9,21 +9,21 @@ module Pliny
         [error.status, headers, [MultiJson.encode(data)]]
       end
 
-      def initialize(message, id)
-        @id = id
-        super(message)
+      def initialize(options={})
+        @id = options[:id]
+        super(options[:message])
       end
     end
 
     class HTTPStatusError < Error
       attr_accessor :status
 
-      def initialize(message = nil, id = nil, status = nil)
-        meta    = Pliny::Errors::META[self.class]
-        message = message || meta[1] + "."
-        id      = id || meta[1].downcase.tr(' ', '_').to_sym
-        @status = status || meta[0]
-        super(message, id)
+      def initialize(options={})
+        meta = Pliny::Errors::META[self.class]
+        options[:message] ||= "#{meta[1]}."
+        options[:id] ||= meta[1].downcase.tr(' ', '_').to_sym
+        @status = options[:status] || meta[0]
+        super(options)
       end
     end
 
@@ -108,6 +108,7 @@ module Pliny
       UnprocessableEntity          => [422, 'Unprocessable entity'],
       TooManyRequests              => [429, 'Too many requests'],
       InternalServerError          => [500, 'Internal server error'],
+      HTTPStatusError              => [500, 'Unspecified'],
       NotImplemented               => [501, 'Not implemented'],
       BadGateway                   => [502, 'Bad gateway'],
       ServiceUnavailable           => [503, 'Service unavailable'],

--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -1,16 +1,17 @@
 module Pliny
   module Errors
     class Error < StandardError
-      attr_accessor :id
+      attr_accessor :id, :metadata
 
       def self.render(error)
         headers = { "Content-Type" => "application/json; charset=utf-8" }
-        data = { id: error.id, message: error.message }
+        data = { id: error.id, message: error.message }.merge(error.metadata)
         [error.status, headers, [MultiJson.encode(data)]]
       end
 
       def initialize(options={})
         @id = options[:id]
+        @metadata = options[:metadata] || {}
         super(options[:message])
       end
     end

--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -17,7 +17,7 @@ module Endpoints
       also_reload '../**/*.rb'
     end
 
-    error Sinatra::NotFound do
+    error Sinatra::NotFound, Sequel::NoMatchingRow do
       raise Pliny::Errors::NotFound
     end
   end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,24 +1,28 @@
 require "spec_helper"
 
 describe Pliny::Errors do
-  it "includes a general error that requires an identifier" do
-    e = Pliny::Errors::Error.new("General error.", :general_error)
-    assert_equal "General error.", e.message
-    assert_equal :general_error, e.id
+  describe Pliny::Errors::Error do
+    it "takes a message" do
+      e = Pliny::Errors::Error.new(message: "Fail.")
+      assert_equal "Fail.", e.message
+    end
+    it "takes an identifier" do
+      e = Pliny::Errors::Error.new(id: :fail)
+      assert_equal :fail, e.id
+    end
   end
 
-  it "includes an HTTP error that will take generic parameters" do
-    e = Pliny::Errors::HTTPStatusError.new(
-      "Custom HTTP error.", :custom_http_error, 499)
-    assert_equal "Custom HTTP error.", e.message
-    assert_equal :custom_http_error, e.id
-    assert_equal 499, e.status
-  end
+  describe Pliny::Errors::HTTPStatusError do
+    it "includes an HTTP error that will take generic parameters" do
+      e = Pliny::Errors::HTTPStatusError.new(status: 499)
+      assert_equal 499, e.status
+    end
 
-  it "includes pre-defined HTTP error templates" do
-    e = Pliny::Errors::NotFound.new
-    assert_equal "Not found.", e.message
-    assert_equal :not_found, e.id
-    assert_equal 404, e.status
+    it "includes pre-defined HTTP error templates" do
+      e = Pliny::Errors::NotFound.new
+      assert_equal "Not found.", e.message
+      assert_equal :not_found, e.id
+      assert_equal 404, e.status
+    end
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -10,6 +10,12 @@ describe Pliny::Errors do
       e = Pliny::Errors::Error.new(id: :fail)
       assert_equal :fail, e.id
     end
+
+    it "takes metadata" do
+      meta = { resource: "artists" }
+      e = Pliny::Errors::Error.new(metadata: meta)
+      assert_equal meta, e.metadata
+    end
   end
 
   describe Pliny::Errors::HTTPStatusError do


### PR DESCRIPTION
- Constructors take options hash
- Support for metadata (new error attributes that are serialized)
- Automatically render 404s for `Sequel::NoMatchingRow` errors