### PR TITLE
Remove console from Procfile

### DIFF
--- a/lib/template/Procfile
+++ b/lib/template/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec puma --config config/puma.rb config.ru
-console: bundle exec bin/console


### PR DESCRIPTION
`console` doesn't belong in Procfile for the same reason `rake` and `rspec` don't: they are auxiliary processes, not really the long-running daemons that constitute the app process formation.

It seems like historically we added this to faciliate `heroku run console`, but the alternative is not that bad (just `run bin/console` instead). On the upside you can now launch all processes on the Procfile without having weird io issues with Foreman.