### PR TITLE
Fix sinatra reloader config

### DIFF
--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -14,7 +14,7 @@ module Endpoints
 
     configure :development do
       register Sinatra::Reloader
-      also_reload '../**/*.rb'
+      also_reload "#{Config.root}/lib/**/*.rb"
     end
 
     error Sinatra::NotFound do


### PR DESCRIPTION
The relative path here is actually from the caller, so this is traversing up the directory structure! Which can slow down the process boot quite a bit.