### PR TITLE
Fix rake schema

### DIFF
--- a/lib/pliny/commands/generator/base.rb
+++ b/lib/pliny/commands/generator/base.rb
@@ -10,7 +10,7 @@ module Pliny::Commands
       attr_reader :name, :stream, :options
 
       def initialize(name, options = {}, stream = $stdout)
-        @name = normalize_name(name)
+        @name = name ? normalize_name(name) : nil
         @options = options
         @stream = stream
       end

--- a/spec/commands/generator/schema_spec.rb
+++ b/spec/commands/generator/schema_spec.rb
@@ -16,15 +16,6 @@ describe Pliny::Commands::Generator::Schema do
     end
   end
 
-  describe '#new#rebuild as seen in schema.rake' do
-    context 'with nil as the name argument' do
-      it 'rebuilds the schema with prmd' do
-        assert_output(/rebuilt/) do
-          Pliny::Commands::Generator::Schema.new(nil).rebuild
-        end
-      end
-    end
-  end
 
   describe '#create' do
     context 'with new layout' do
@@ -55,6 +46,14 @@ describe Pliny::Commands::Generator::Schema do
   end
 
   describe '#rebuild' do
+    context 'with nil as the name argument (as used in schema.rake)' do
+      it 'rebuilds the schema with prmd' do
+        assert_output(/rebuilt/) do
+          Pliny::Commands::Generator::Schema.new(nil).rebuild
+        end
+      end
+    end
+
     context 'with new layout' do
       before do
         subject.rebuild

--- a/spec/commands/generator/schema_spec.rb
+++ b/spec/commands/generator/schema_spec.rb
@@ -1,3 +1,4 @@
+require 'pliny/commands/creator'
 require 'pliny/commands/generator'
 require 'pliny/commands/generator/schema'
 require 'spec_helper'
@@ -12,6 +13,16 @@ describe Pliny::Commands::Generator::Schema do
       # schema work depends on files seeded by the template
       Pliny::Commands::Creator.run([app_dir], {}, StringIO.new)
       Dir.chdir(app_dir, &example)
+    end
+  end
+
+  describe '#new#rebuild as seen in schema.rake' do
+    context 'with nil as the name argument' do
+      it 'rebuilds the schema with prmd' do
+        assert_output(/rebuilt/) do
+          Pliny::Commands::Generator::Schema.new(nil).rebuild
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I noticed that the `rake schema` task was throwing a NoMethodError.
In *lib/tasks/schema.rb* the Pliny::Commands::Generator::Schema.new(nil).rebuild.

The error was occurring because the private method in the Base class `#normalize_name` was
trying to `#underscore` nil.

I added a ternary in the initialization for the name attribute. 

Basically Don't normalize if name is nil! 