### PR TITLE
Bring route_signature back to instruments

### DIFF
--- a/lib/pliny/middleware/instruments.rb
+++ b/lib/pliny/middleware/instruments.rb
@@ -20,6 +20,10 @@ module Pliny::Middleware
 
       status, headers, response = @app.call(env)
 
+      if route = env["sinatra.route"]
+        data.merge!(route_signature: route.split(" ").last)
+      end
+
       elapsed = (Time.now - start).to_f
       Pliny.log(data.merge(
         at:              "finish",

--- a/spec/middleware/instruments_spec.rb
+++ b/spec/middleware/instruments_spec.rb
@@ -34,6 +34,7 @@ describe Pliny::Middleware::Instruments do
       at:              "finish",
       method:          "GET",
       path:            "/apps/123",
+      route_signature: "/apps/:id",
       status:          201
     ))
     get "/apps/123"


### PR DESCRIPTION
rely on sinatra.route as set by Sinatra 1.4.6 and up