### PR TITLE
Add GET /health and /health/db endpoints

### DIFF
--- a/lib/template/lib/endpoints/health.rb
+++ b/lib/template/lib/endpoints/health.rb
@@ -14,11 +14,11 @@ module Endpoints
       private
 
       def database?
-        raise Pliny::Errors::NotFound if DB.nil?
+        fail Pliny::Errors::NotFound if DB.nil?
       end
 
       def database_available?
-        raise Pliny::Errors::ServiceUnavailable unless DB.test_connection
+        fail Pliny::Errors::ServiceUnavailable unless DB.test_connection
       rescue Sequel::Error => e
         message = e.message.strip
         Pliny.log(db: true, health: true, at: 'exception', message: message)

--- a/lib/template/lib/endpoints/health.rb
+++ b/lib/template/lib/endpoints/health.rb
@@ -2,7 +2,7 @@ module Endpoints
   class Health < Base
      namespace '/health' do
       get do
-        200
+        encode {}
       end
     end
   end

--- a/lib/template/lib/endpoints/health.rb
+++ b/lib/template/lib/endpoints/health.rb
@@ -1,0 +1,9 @@
+module Endpoints
+  class Health < Base
+     namespace '/health' do
+      get do
+        200
+      end
+    end
+  end
+end

--- a/lib/template/lib/endpoints/health.rb
+++ b/lib/template/lib/endpoints/health.rb
@@ -1,6 +1,6 @@
 module Endpoints
   class Health < Base
-     namespace '/health' do
+    namespace '/health' do
       get do
         encode({})
       end

--- a/lib/template/lib/endpoints/health.rb
+++ b/lib/template/lib/endpoints/health.rb
@@ -2,7 +2,27 @@ module Endpoints
   class Health < Base
      namespace '/health' do
       get do
-        encode {}
+        encode({})
+      end
+
+      get '/db' do
+        database?
+        database_available?
+        encode({})
+      end
+
+      private
+
+      def database?
+        raise Pliny::Errors::NotFound if DB.nil?
+      end
+
+      def database_available?
+        raise Pliny::Errors::ServiceUnavailable unless DB.test_connection
+      rescue Sequel::Error => e
+        message = e.message.strip
+        Pliny.log(db: true, health: true, at: 'exception', message: message)
+        raise Pliny::Errors::ServiceUnavailable
       end
     end
   end

--- a/lib/template/lib/routes.rb
+++ b/lib/template/lib/routes.rb
@@ -15,6 +15,7 @@ Routes = Rack::Builder.new do
 
   use Pliny::Router do
     # mount all endpoints here
+    mount Endpoints::Health
     mount Endpoints::Schema
   end
 

--- a/lib/template/spec/endpoints/health_spec.rb
+++ b/lib/template/spec/endpoints/health_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Endpoints::Health do
+  include Rack::Test::Methods
+
+  def app
+    Endpoints::Health
+  end
+
+  describe 'GET /health' do
+    it 'returns a 200' do
+      get '/health'
+      assert 200, last_response.status
+    end
+  end
+end

--- a/lib/template/spec/endpoints/health_spec.rb
+++ b/lib/template/spec/endpoints/health_spec.rb
@@ -10,7 +10,10 @@ describe Endpoints::Health do
   describe 'GET /health' do
     it 'returns a 200' do
       get '/health'
-      assert 200, last_response.status
+      assert_equal(200, last_response.status)
+      assert_equal('application/json;charset=utf-8', last_response.headers['Content-Type'])
+      assert_equal(2, last_response.headers['Content-Length'].to_i)
+      assert_equal({}, MultiJson.decode(last_response.body))
     end
   end
 end

--- a/lib/template/spec/endpoints/health_spec.rb
+++ b/lib/template/spec/endpoints/health_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::Health do
+RSpec.describe Endpoints::Health do
   include Rack::Test::Methods
 
   def app
@@ -10,6 +10,42 @@ describe Endpoints::Health do
   describe 'GET /health' do
     it 'returns a 200' do
       get '/health'
+      assert_equal(200, last_response.status)
+      assert_equal('application/json;charset=utf-8', last_response.headers['Content-Type'])
+      assert_equal(2, last_response.headers['Content-Length'].to_i)
+      assert_equal({}, MultiJson.decode(last_response.body))
+    end
+  end
+
+  describe 'GET /health/db' do
+    it 'raises a 404 when no database is available' do
+      allow(DB).to receive(:nil?).and_return(true)
+
+      assert_raises Pliny::Errors::NotFound do
+        get '/health/db'
+      end
+    end
+
+    it 'raises a 503 on Sequel exceptions' do
+      allow(DB).to receive(:test_connection).and_raise(Sequel::Error)
+
+      assert_raises Pliny::Errors::ServiceUnavailable do
+        get '/health/db'
+      end
+    end
+
+    it 'raises a 503 when connection testing fails' do
+      allow(DB).to receive(:test_connection).and_return(false)
+
+      assert_raises Pliny::Errors::ServiceUnavailable do
+        get '/health/db'
+      end
+    end
+
+    it 'returns a 200' do
+      allow(DB).to receive(:test_connection).and_return(true)
+
+      get '/health/db'
       assert_equal(200, last_response.status)
       assert_equal('application/json;charset=utf-8', last_response.headers['Content-Type'])
       assert_equal(2, last_response.headers['Content-Length'].to_i)


### PR DESCRIPTION
For every pliny project I've done, I've added a `GET /health` endpoint to hook up to Pingdom. To reduce the use of my mad copy pasting skills, I'm upstreaming it.

```
$ curl -i :5000/health
HTTP/1.1 200 OK
Content-Type: application/json;charset=utf-8
X-Content-Type-Options: nosniff
Vary: Accept-Encoding
Request-Id: 1620b575-4033-40a7-a8e6-17a1a4c94523
Content-Length: 2

{}
```

Also adds `GET /health/db` to test the Sequel database connection via `DB.test_connection`