### PR TITLE
DB constant

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -34,7 +34,7 @@ begin
     task :seed do
       if File.exist?('./db/seeds.rb')
         database_urls.each do |database_url|
-          Sequel.connect(database_url)
+          DB = Sequel.connect(database_url)
           load 'db/seeds.rb'
         end
         disconnect

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -34,7 +34,9 @@ begin
     task :seed do
       if File.exist?('./db/seeds.rb')
         database_urls.each do |database_url|
-          DB = Sequel.connect(database_url)
+          # make a DB instance available to the seeds file
+          self.class.send(:remove_const, 'DB') if self.class.const_defined?('DB')
+          self.class.const_set('DB', Sequel.connect(database_url))
           load 'db/seeds.rb'
         end
         disconnect

--- a/lib/template/config/initializers/database.rb
+++ b/lib/template/config/initializers/database.rb
@@ -5,6 +5,6 @@ database_setup_proc = lambda do |conn|
   conn.execute "SET application_name = '#{process_identifier}'"
 end
 
-Sequel.connect(Config.database_url,
+DB = Sequel.connect(Config.database_url,
   max_connections: Config.db_pool,
   after_connect: database_setup_proc)

--- a/lib/template/db/seeds.rb
+++ b/lib/template/db/seeds.rb
@@ -4,6 +4,5 @@
 # db with db:setup).
 #
 # Seeding can occur multiple times during the execution of a single Rake task
-# because seeding should occur in all environments (development, testing,
-# etc.). The currently connected database can be accessed via
-# `Sequel::DATABASES.last`.
+# because it applies to all your app environments (eg: test and development).
+# An instance of the current database connection is available as `DB`.


### PR DESCRIPTION
Make a `DB` constant available to the app and seeds, useful for non-model specific queries (eg: `DB.transaction`, `DB.test_connection`, etc).

Checked it works with Puma workers.