### PR TITLE
set search_path on schema dumps

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -100,12 +100,11 @@ begin
 
         # add migrations used to compose this schema
         db = Sequel.connect(database_urls.first)
-
-        # set the search_path so migrations are added in the right schema
-        search_path = db.dataset.with_sql("SHOW search_path").single_value
-        schema << "SET search_path = #{search_path};\n\n"
-
         if db.table_exists?(:schema_migrations)
+          # set the search_path so migrations are added in the right schema
+          search_path = db.dataset.with_sql("SHOW search_path").single_value
+          schema << "SET search_path = #{search_path};\n\n"
+
           db[:schema_migrations].each do |migration|
             schema << db[:schema_migrations].insert_sql(migration) + ";\n"
           end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -100,6 +100,11 @@ begin
 
         # add migrations used to compose this schema
         db = Sequel.connect(database_urls.first)
+
+        # set the search_path so migrations are added in the right schema
+        search_path = db.dataset.with_sql("SHOW search_path").single_value
+        schema << "SET search_path = #{search_path};\n\n"
+
         if db.table_exists?(:schema_migrations)
           db[:schema_migrations].each do |migration|
             schema << db[:schema_migrations].insert_sql(migration) + ";\n"


### PR DESCRIPTION
This ensures that the generated schema can be restored even on
databases with different schemas, where the original pg_dump might
leave the search_path on a place where schema_migrations is not
visible.

Fix #224