### PR TITLE
Enable RSpec zero monkey patching mode

### DIFF
--- a/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::<%= plural_class_name %> do
+RSpec.describe Endpoints::<%= plural_class_name %> do
   include Committee::Test::Methods
   include Rack::Test::Methods
 

--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::<%= plural_class_name %> do
+RSpec.describe Endpoints::<%= plural_class_name %> do
   include Committee::Test::Methods
   include Rack::Test::Methods
 

--- a/lib/pliny/templates/endpoint_test.erb
+++ b/lib/pliny/templates/endpoint_test.erb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::<%= plural_class_name %> do
+RSpec.describe Endpoints::<%= plural_class_name %> do
   include Rack::Test::Methods
 
   describe "GET <%= url_path %>" do

--- a/lib/pliny/templates/mediator_test.erb
+++ b/lib/pliny/templates/mediator_test.erb
@@ -1,5 +1,5 @@
 require "spec_helper"
 
-describe Mediators::<%= singular_class_name %> do
-  
+RSpec.describe Mediators::<%= singular_class_name %> do
+
 end

--- a/lib/pliny/templates/model_test.erb
+++ b/lib/pliny/templates/model_test.erb
@@ -1,4 +1,4 @@
 require "spec_helper"
 
-describe <%= singular_class_name %> do
+RSpec.describe <%= singular_class_name %> do
 end

--- a/lib/pliny/templates/serializer_test.erb
+++ b/lib/pliny/templates/serializer_test.erb
@@ -1,4 +1,4 @@
 require "spec_helper"
 
-describe Serializers::<%= singular_class_name %> do
+RSpec.describe Serializers::<%= singular_class_name %> do
 end

--- a/lib/template/spec/endpoints/schema_spec.rb
+++ b/lib/template/spec/endpoints/schema_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Endpoints::Schema do
+RSpec.describe Endpoints::Schema do
   include Rack::Test::Methods
 
   let(:schema_filename) { "#{Config.root}/schema/schema.json" }

--- a/lib/template/spec/spec_helper.rb
+++ b/lib/template/spec/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.disable_monkey_patching!
   config.expect_with :minitest
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
RSpec 3 configuration has [`disable_monkey_patching!`][1] option that removes monkey patching of the methods like `describe` and `shared_examples_for` onto `main` and `Module`. This should be default in RSpec 4.

This change will require update for existing specs on apps, but [transpec][2] gem might help with that.

I would be happy to know your thought on this one. Thank you for doing awesome job! :smile: 

[1]: http://www.rubydoc.info/gems/rspec-core/RSpec/Core/Configuration#disable_monkey_patching%21-instance_method
[2]: https://github.com/yujinakayama/transpec