### PR TITLE
Fix pliny-new command banner message

### DIFF
--- a/bin/pliny-new
+++ b/bin/pliny-new
@@ -5,7 +5,7 @@ require_relative '../lib/pliny/commands/creator'
 
 OptionParser.new do |options|
   opts = {}
-  options.banner = "Usage: pliny-new app-name [options]"
+  options.banner = "Usage: pliny-new NAME"
 
   begin
     options.parse!


### PR DESCRIPTION
If I'm not mistaken `pliny-new` accepts no options except an app name. It was a bit confusing when I've tried to find possible options :smile: 

Also I took a chance and messaged format of the banner message, so it matches the same style `pliny-generate` has. Consistency always matters :smiley: 


