### PR TITLE
Re-raising the error from the root cause rather than raising a new error

### DIFF
--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -60,7 +60,7 @@ module Pliny
         rescue
           log_to_stream(stream, data.merge(
             at: "exception", elapsed: (Time.now - start).to_f))
-          raise
+          raise $!
         end
       end
     end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -16,6 +16,14 @@ describe Pliny::Log do
     Pliny.log(foo: "bar", baz: 42)
   end
 
+  it "re-raises errors" do
+    assert_raises(RuntimeError) do
+      Pliny.log(foo: "bar") do
+        raise RuntimeError
+      end
+    end
+  end
+
   it "supports blocks to log stages and elapsed" do
     mock(@io).print "foo=bar at=start\n"
     mock(@io).print "foo=bar at=finish elapsed=0.000\n"


### PR DESCRIPTION
Otherwise the raise will show the backtrace from the `log`/`log_to_stream` method.