### PR TITLE
Remove rack_env and make pliny_env mandatory

### DIFF
--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -11,6 +11,7 @@ module Config
 
   # Mandatory -- exception is raised for these variables when missing.
   mandatory :database_url, string
+  mandatory :pliny_env,    string
 
   # Optional -- value is returned or `nil` if it wasn't present.
   optional :placeholder,         string
@@ -22,13 +23,11 @@ module Config
   override :db_pool,          5,    int
   override :deployment,       'production', string
   override :force_ssl,        true,  bool
-  override :pliny_env,        'development', string
   override :port,             5000, int
   override :pretty_json,      false, bool
   override :puma_max_threads, 16,   int
   override :puma_min_threads, 1,    int
   override :puma_workers,     3,    int
-  override :rack_env,         'development', string
   override :raise_errors,     false,         bool
   override :root,             File.expand_path("../../", __FILE__), string
   override :timeout,          10,    int


### PR DESCRIPTION
That's my way of saying I agree with [brandur's comments](https://github.com/interagent/pliny/pull/138#discussion_r49124034).

Closes #237