### PR TITLE
No more deprecated `-i` pg_dump option

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -92,7 +92,7 @@ begin
       task :dump do
         file = File.join("db", "schema.sql")
         database_url = database_urls.first
-        `pg_dump -i -s -x -O -f #{file} #{database_url}`
+        `pg_dump -s -x -O -f #{file} #{database_url}`
 
         schema = File.read(file)
         # filter all COMMENT ON EXTENSION, only owners and the db


### PR DESCRIPTION
This option is deprecated since [PostgreSQL 8.4][1]. So it does not make sense to keep it.

`pg_dump` bundled with PostgreSQL 9.5 even fails to run with this option. That makes impossible to run `rake db:schema:dump`. It looks like this:

```
> bundle exec rake db:schema:dump
pg_dump: invalid option -- i
Try "pg_dump --help" for more information.
```

Thank you for everything you do! :heart: 

[1]: http://www.postgresql.org/docs/8.4/static/app-pgdump.html