### PR TITLE
Add app_name config variable and log it by default

### DIFF
--- a/lib/pliny/commands/creator.rb
+++ b/lib/pliny/commands/creator.rb
@@ -22,14 +22,14 @@ module Pliny::Commands
 
       FileUtils.copy_entry template_dir, app_dir
       FileUtils.rm_rf("#{app_dir}/.git")
-      setup_database_urls
+      setup_environments
       display 'Pliny app created. To start, run:'
       display "cd #{app_dir} && bin/setup"
     end
 
     protected
 
-    def setup_database_urls
+    def setup_environments
       db = URI.parse("postgres:///#{name}")
       {
         '.env.sample' => 'development',
@@ -42,7 +42,8 @@ module Pliny::Commands
           # ruby's URI#to_s renders foo:/bar when there's no host
           # we want foo:///bar instead!
           db_url = db.to_s.sub(':/', ':///')
-          f.puts env.sub(/DATABASE_URL=.*/, "DATABASE_URL=#{db_url}")
+          f.puts env.sub(/APP_NAME=.*/, "APP_NAME=#{name}")
+                    .sub(/DATABASE_URL=.*/, "DATABASE_URL=#{db_url}")
         end
       end
     end

--- a/lib/template/.env.sample
+++ b/lib/template/.env.sample
@@ -1,3 +1,4 @@
+APP_NAME=pliny
 DATABASE_URL=postgres://localhost/pliny-development
 PLINY_ENV=development
 TZ=UTC

--- a/lib/template/.env.test
+++ b/lib/template/.env.test
@@ -1,3 +1,4 @@
+APP_NAME=pliny
 DATABASE_URL=postgres://localhost/pliny-test
 PLINY_ENV=test
 TZ=UTC

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -13,6 +13,7 @@ module Config
   mandatory :database_url, string
 
   # Optional -- value is returned or `nil` if it wasn't present.
+  optional :app_name,            string
   optional :placeholder,         string
   optional :versioning_default,  string
   optional :versioning_app_name, string

--- a/lib/template/config/initializers/log.rb
+++ b/lib/template/config/initializers/log.rb
@@ -1,3 +1,2 @@
-Pliny.default_context = {
-  app: Config.app_name
-}
+Pliny.default_context = {}
+Pliny.default_context[:app] = Config.app_name if Config.app_name

--- a/lib/template/config/initializers/log.rb
+++ b/lib/template/config/initializers/log.rb
@@ -1,1 +1,3 @@
-Pliny.default_context = {}
+Pliny.default_context = {
+  app: Config.app_name
+}


### PR DESCRIPTION
When creating new Pliny apps, one of the first things I do is to add `app_name` as a config var, and log it out by default.

When calling `Pliny.log(hello_world: true)` it'll yield the log message

```
app=my-fancy-app hello_world
```

This change makes it easy to search for log messages from a single app when multiple apps are being pooled into the same Splunk instance.

**Note** This is not the same as the Heroku app name, that config var will be set automatically in `HEROKU_APP_NAME` if [dyno metadata is enabled](https://devcenter.heroku.com/articles/dyno-metadata).