### PR TITLE
Add deployment to default log context

### DIFF
--- a/lib/template/.env.sample
+++ b/lib/template/.env.sample
@@ -1,5 +1,6 @@
 APP_NAME=pliny
 DATABASE_URL=postgres://localhost/pliny-development
+DEPLOYMENT=development
 PLINY_ENV=development
 TZ=UTC
 RAISE_ERRORS=true

--- a/lib/template/.env.test
+++ b/lib/template/.env.test
@@ -1,5 +1,6 @@
 APP_NAME=pliny
 DATABASE_URL=postgres://localhost/pliny-test
+DEPLOYMENT=test
 PLINY_ENV=test
 TZ=UTC
 RAISE_ERRORS=true

--- a/lib/template/config/initializers/log.rb
+++ b/lib/template/config/initializers/log.rb
@@ -1,2 +1,3 @@
 Pliny.default_context = {}
 Pliny.default_context[:app] = Config.app_name if Config.app_name
+Pliny.default_context[:deployment] = Config.deployment


### PR DESCRIPTION
In conjunction with #240, the default log context will contain the app and the deployment, the benefit of doing this is that log entries look like this

```
app=my-pliny-app deployment=production
```

This PR will be rebased is and when #240 hits master.