### PR TITLE
Remove rack_env and set it to only always be development or deployment

### DIFF
--- a/lib/pliny/config_helpers.rb
+++ b/lib/pliny/config_helpers.rb
@@ -49,6 +49,14 @@ module Pliny
       end
     end
 
+    def rack_env
+      if pliny_env == "development" || pliny_env == "test"
+        "development"
+      else
+        "deployment"
+      end
+    end
+
     private
 
     def cast(value, method)
@@ -96,5 +104,7 @@ module Pliny
 
 end
 
-# Supress the "use RbConfig instead" warning.
-Object.send(:remove_const, :Config) if Object.const_defined?(:Config)
+# Supress the "use RbConfig instead" warning
+if Object.const_defined?(:Config) && !Config.is_a?(Pliny::CastingConfigHelpers)
+  Object.send(:remove_const, :Config)
+end

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -28,7 +28,6 @@ module Config
   override :puma_max_threads, 16,   int
   override :puma_min_threads, 1,    int
   override :puma_workers,     3,    int
-  override :rack_env,         'development', string
   override :raise_errors,     false,         bool
   override :root,             File.expand_path("../../", __FILE__), string
   override :timeout,          10,    int

--- a/lib/template/config/puma.rb
+++ b/lib/template/config/puma.rb
@@ -1,6 +1,6 @@
 require "./config/config"
 
-environment Config.pliny_env
+environment Config.rack_env
 port Config.port
 quiet
 threads Config.puma_min_threads, Config.puma_max_threads

--- a/spec/config_helpers_spec.rb
+++ b/spec/config_helpers_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+require "pliny/config_helpers"
+
+describe Pliny::CastingConfigHelpers do
+
+  describe "#rack_env" do
+    it "is development if pliny_env is development" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :pliny_env, 'development', string
+      end
+
+      assert_equal "development", config.rack_env
+    end
+
+    it "is development if pliny_env is test" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :pliny_env, 'test', string
+      end
+
+      assert_equal "development", config.rack_env
+    end
+
+    it "is deployment if pliny_env is production" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :pliny_env, 'production', string
+      end
+
+      assert_equal "deployment", config.rack_env
+    end
+
+    it "is deployment if pliny_env is nil" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :pliny_env, '', string
+      end
+
+      assert_equal "deployment", config.rack_env
+    end
+
+    it "is deployment if pliny_env is another value" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :pliny_env, 'staging', string
+      end
+
+      assert_equal "deployment", config.rack_env
+    end
+  end
+end

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,7 +1,13 @@
+require "pliny/config_helpers"
+
 # Supress the "use RbConfig instead" warning.
-Object.send(:remove_const, :Config) if Object.const_defined?(:Config)
+if Object.const_defined?(:Config) && !Config.is_a?(Pliny::CastingConfigHelpers)
+  Object.send(:remove_const, :Config)
+end
 
 module Config
+  extend Pliny::CastingConfigHelpers
+
   def self.pretty_json
     true
   end


### PR DESCRIPTION
Rack doesn't accept "production" as a RACK_ENV variable. It requires
development or deployment.
http://unicorn.bogomips.org/unicorn_1.html#rack-environment

Setting it to another value means some middlewares will not be
automatically added:
https://github.com/rack/rack/blob/028438ffffd95ce1f6197d38c04fa5ea6a034a85/lib/rack/server.rb#L228

Not having those middlewares is known to cause latency with some
browsers.