### PR TITLE
Add app.json postdeploy script to run migrations

### DIFF
--- a/lib/template/app.json.erb
+++ b/lib/template/app.json.erb
@@ -8,6 +8,10 @@
     "PLINY_ENV": "production"
   },
 
+  "scripts": {
+    "postdeploy": "bundle exec rake db:schema:load db:migrate"
+  },
+
   "addons": [
     "heroku-postgresql"
   ]


### PR DESCRIPTION
Adds `bundle exec rake db:schema:load db:migrate` as a `postdeploy` script when creating apps with Heroku App Setups. This will cause Heroku Buttons and review apps to get the database prepared while spinning up the app.