### PR TITLE
Read ruby version from .ruby-version in Gemfile

### DIFF
--- a/lib/template/Gemfile
+++ b/lib/template/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "2.3.0"
+ruby IO.read(File.join(__dir__, ".ruby-version")).strip
 
 gem "multi_json"
 gem "oj"


### PR DESCRIPTION
Never again forget .ruby-version or Gemfile when updating the ruby version (example: 63cec6e1985fab54976b594c920131b56feffc8c)