### PR TITLE
Remove the connection from `Sequel::DATABASES` when disconnecting in DbSupport

### DIFF
--- a/lib/pliny/db_support.rb
+++ b/lib/pliny/db_support.rb
@@ -24,6 +24,7 @@ module Pliny
       instance = new(url, logger)
       yield instance
       instance.disconnect
+      Sequel::DATABASES.delete(instance)
     end
 
     attr_accessor :db


### PR DESCRIPTION
Fix #247