### PR TITLE
Upgrade sinatra and sinatra-contrib

### DIFF
--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "multi_json",     "~> 1.9",  ">= 1.9.3"
   gem.add_dependency "prmd",           "~> 0.11", ">= 0.11.4"
 
-  gem.add_dependency "sinatra",        "~> 1.4",  ">= 1.4.5"
+  gem.add_dependency "sinatra",        "~> 1.4",  ">= 1.4.7"
   gem.add_dependency "http_accept",    "~> 0.1",  ">= 0.1.5"
   gem.add_dependency "sinatra-router", "~> 0.2",  ">= 0.2.3"
   gem.add_dependency "thor",           "~> 0.19", ">= 0.19.1"
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rack-test", "~> 0.6", ">= 0.6.2"
   gem.add_development_dependency "rr", "~> 1.1", ">= 1.1.2"
   gem.add_development_dependency "rspec", "~> 3.1", ">= 3.1.0"
-  gem.add_development_dependency "sinatra-contrib", "~> 1.4", ">= 1.4.2"
+  gem.add_development_dependency "sinatra-contrib", "~> 1.4", ">= 1.4.7"
   gem.add_development_dependency "timecop", "~> 0.7", ">= 0.7.1"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pg",             "~> 0.17", ">= 0.17.1"


### PR DESCRIPTION
Older versions than 1.4.7 of sinatra-contrib raise a warning on Ruby 2.3 due to a deprecation of Thread.exclusive. See https://github.com/sinatra/sinatra-contrib/pull/184. This issue has been leaving me reluctant to cut a new release of Pliny, as every request in development would output `Thread.exclusive is deprecated, use Mutex` and a stack trace. Eew.