### PR TITLE
Disable Rollbar monkey patching

### DIFF
--- a/lib/template/config/initializers/rollbar.rb
+++ b/lib/template/config/initializers/rollbar.rb
@@ -1,5 +1,6 @@
 Rollbar.configure do |config|
   config.enabled = ENV.has_key?('ROLLBAR_ACCESS_TOKEN')
+  config.disable_monkey_patch = true
   config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
   config.environment = ENV['ROLLBAR_ENV']
   config.logger = Pliny::RollbarLogger.new


### PR DESCRIPTION
During investigation of an incident I noticed that Pliny has been double posting to Rollbar for a while. I traced this to a missing `disable_monkey_patch` as a part of #110 a while back.

**Note** Bringing this change in might have the side effect of error reporting being disabled in certain places, for example in Sidekiq workers and other `bin/` scripts.