### PR TITLE
Support 'Origin' CORS header for Safari

### DIFF
--- a/lib/pliny/middleware/cors.rb
+++ b/lib/pliny/middleware/cors.rb
@@ -4,7 +4,7 @@ module Pliny::Middleware
     ALLOW_METHODS  =
       %w( GET POST PUT PATCH DELETE OPTIONS ).freeze
     ALLOW_HEADERS  =
-      %w( Content-Type Accept Authorization Cache-Control If-None-Match If-Modified-Since ).freeze
+      %w( Content-Type Accept Authorization Cache-Control If-None-Match If-Modified-Since Origin).freeze
     EXPOSE_HEADERS =
       %w( Cache-Control Content-Language Content-Type Expires Last-Modified Pragma ).freeze
 


### PR DESCRIPTION
Some Safari versions will reject CORS responses without this.

Additional details: https://github.com/cyu/rack-cors/issues/116