### PR TITLE
Config cleanup

### DIFF
--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -18,18 +18,18 @@ module Config
   optional :versioning_app_name, string
 
   # Override -- value is returned or the set default.
-  override :database_timeout, 10,    int
-  override :db_pool,          5,    int
+  override :database_timeout, 10,           int
+  override :db_pool,          5,            int
   override :deployment,       'production', string
-  override :force_ssl,        true,  bool
+  override :force_ssl,        true,         bool
   override :pliny_env,        'production', string
-  override :port,             5000, int
-  override :pretty_json,      false, bool
-  override :puma_max_threads, 16,   int
-  override :puma_min_threads, 1,    int
-  override :puma_workers,     3,    int
-  override :raise_errors,     false,         bool
+  override :port,             5000,         int
+  override :pretty_json,      false,        bool
+  override :puma_max_threads, 16,           int
+  override :puma_min_threads, 1,            int
+  override :puma_workers,     3,            int
+  override :raise_errors,     false,        bool
   override :root,             File.expand_path("../../", __FILE__), string
-  override :timeout,          10,    int
-  override :versioning,       false, bool
+  override :timeout,          10,           int
+  override :versioning,       false,        bool
 end

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -14,7 +14,6 @@ module Config
 
   # Optional -- value is returned or `nil` if it wasn't present.
   optional :app_name,            string
-  optional :placeholder,         string
   optional :versioning_default,  string
   optional :versioning_app_name, string
 

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -22,7 +22,7 @@ module Config
   override :db_pool,          5,    int
   override :deployment,       'production', string
   override :force_ssl,        true,  bool
-  override :pliny_env,        'development', string
+  override :pliny_env,        'production', string
   override :port,             5000, int
   override :pretty_json,      false, bool
   override :puma_max_threads, 16,   int


### PR DESCRIPTION
* Removes `Config.placeholder`, not referred to anywhere in Pliny. Not sure what the intention even is.
* Changes the default `Config.pliny_env` to `production`. `.env.sample` and `.env.test` do the right thing already.