### PR TITLE
Make Rollbar dependency optional

### DIFF
--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake", "~> 0.8", ">= 0.8.7"
   gem.add_development_dependency "rack-test", "~> 0.6", ">= 0.6.2"
-  gem.add_development_dependency "rr", "~> 1.1", ">= 1.1.2"
   gem.add_development_dependency "rspec", "~> 3.1", ">= 3.1.0"
   gem.add_development_dependency "sinatra-contrib", "~> 1.4", ">= 1.4.7"
   gem.add_development_dependency "timecop", "~> 0.7", ">= 0.7.1"

--- a/spec/commands/generator_spec.rb
+++ b/spec/commands/generator_spec.rb
@@ -9,9 +9,7 @@ describe Pliny::Commands::Generator do
   before do
     Timecop.freeze(@t = Time.now)
 
-    any_instance_of(Pliny::Commands::Generator::Base) do |klass|
-      stub(klass).display
-    end
+    allow_any_instance_of(Pliny::Commands::Generator::Base).to receive(:display)
   end
 
   around do |example|

--- a/spec/commands/updater_spec.rb
+++ b/spec/commands/updater_spec.rb
@@ -6,7 +6,7 @@ describe Pliny::Commands::Updater do
     @io = StringIO.new
     @cmd = Pliny::Commands::Updater.new(@io)
 
-    stub(@cmd).exec_patch
+    allow(@cmd).to receive(:exec_patch)
   end
 
   describe "#run!" do

--- a/spec/error_reporter_spec.rb
+++ b/spec/error_reporter_spec.rb
@@ -14,9 +14,9 @@ describe Pliny::ErrorReporter do
     end
 
     it "notifies rollbar" do
-      any_instance_of(Pliny::ErrorReporter::RollbarReporter) do |klass|
-        stub(klass).notify(exception, context: context, rack_env: rack_env)
-      end
+      expect_any_instance_of(Pliny::ErrorReporter::RollbarReporter).
+        to receive(:notify).
+        with(exception, context: context, rack_env: rack_env)
 
       notify_reporter
     end

--- a/spec/helpers/encode_spec.rb
+++ b/spec/helpers/encode_spec.rb
@@ -11,7 +11,7 @@ describe Pliny::Helpers::Encode do
   end
 
   before do
-    stub(Config).pretty_json { false }
+    allow(Config).to receive(:pretty_json) { false }
   end
 
   it "sets the Content-Type" do
@@ -33,7 +33,7 @@ describe Pliny::Helpers::Encode do
   end
 
   it "encodes in pretty mode when set by config" do
-    stub(Config).pretty_json { true }
+    allow(Config).to receive(:pretty_json) { true }
     payload = { "foo" => "bar" }
     post "/", payload
     assert_equal MultiJson.encode(payload, pretty: true), last_response.body

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -5,7 +5,7 @@ describe Pliny::Log do
     @io = StringIO.new
     Pliny.stdout = @io
     Pliny.stderr = @io
-    stub(@io).print
+    allow(@io).to receive(:print)
   end
 
   after do
@@ -13,7 +13,7 @@ describe Pliny::Log do
   end
 
   it "logs in structured format" do
-    mock(@io).print "foo=bar baz=42\n"
+    expect(@io).to receive(:print).with("foo=bar baz=42\n")
     Pliny.log(foo: "bar", baz: 42)
   end
 
@@ -26,26 +26,26 @@ describe Pliny::Log do
   end
 
   it "supports blocks to log stages and elapsed" do
-    mock(@io).print "foo=bar at=start\n"
-    mock(@io).print "foo=bar at=finish elapsed=0.000\n"
+    expect(@io).to receive(:print).with("foo=bar at=start\n")
+    expect(@io).to receive(:print).with("foo=bar at=finish elapsed=0.000\n")
     Pliny.log(foo: "bar") do
     end
   end
 
   it "merges default context" do
     Pliny.default_context = { app: "pliny" }
-    mock(@io).print "app=pliny foo=bar\n"
+    expect(@io).to receive(:print).with("app=pliny foo=bar\n")
     Pliny.log(foo: "bar")
   end
 
   it "merges context from RequestStore" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
-    mock(@io).print "app=pliny foo=bar\n"
+    expect(@io).to receive(:print).with("app=pliny foo=bar\n")
     Pliny.log(foo: "bar")
   end
 
   it "supports a context" do
-    mock(@io).print "app=pliny foo=bar\n"
+    expect(@io).to receive(:print).with("app=pliny foo=bar\n")
     Pliny.context(app: "pliny") do
       Pliny.log(foo: "bar")
     end
@@ -53,14 +53,14 @@ describe Pliny::Log do
 
   it "local context does not overwrite default context" do
     Pliny.default_context = { app: "pliny" }
-    mock(@io).print "app=not_pliny foo=bar\n"
+    expect(@io).to receive(:print).with("app=not_pliny foo=bar\n")
     Pliny.log(app: 'not_pliny', foo: "bar")
     assert Pliny.default_context[:app] == "pliny"
   end
 
   it "local context does not overwrite request context" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
-    mock(@io).print "app=not_pliny foo=bar\n"
+    expect(@io).to receive(:print).with("app=not_pliny foo=bar\n")
     Pliny.context(app: "not_pliny") do
       Pliny.log(foo: "bar")
     end
@@ -69,7 +69,7 @@ describe Pliny::Log do
 
   it "local context does not propagate outside" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
-    mock(@io).print "app=pliny foo=bar\n"
+    expect(@io).to receive(:print).with("app=pliny foo=bar\n")
     Pliny.context(app: "not_pliny", test: 123) do
     end
     Pliny.log(foo: "bar")
@@ -78,7 +78,7 @@ describe Pliny::Log do
   it "logs exceptions" do
     Pliny::RequestStore.store[:log_context] = { app: "pliny" }
     e = RuntimeError.new
-    mock(@io).print "app=pliny exception class=RuntimeError message=RuntimeError exception_id=#{e.object_id}\n"
+    expect(@io).to receive(:print).with("app=pliny exception class=RuntimeError message=RuntimeError exception_id=#{e.object_id}\n")
     Pliny.log_exception(e)
   end
 end

--- a/spec/middleware/instruments_spec.rb
+++ b/spec/middleware/instruments_spec.rb
@@ -23,13 +23,13 @@ describe Pliny::Middleware::Instruments do
   end
 
   it "performs logging" do
-    mock(Pliny).log(hash_including(
+    expect(Pliny).to receive(:log).with(hash_including(
       instrumentation: true,
       at:              "start",
       method:          "GET",
       path:            "/apps/123",
     ))
-    mock(Pliny).log(hash_including(
+    expect(Pliny).to receive(:log).with(hash_including(
       instrumentation: true,
       at:              "finish",
       method:          "GET",
@@ -41,8 +41,8 @@ describe Pliny::Middleware::Instruments do
   end
 
   it "respects Pliny error status codes" do
-    mock(Pliny).log.with_any_args
-    mock(Pliny).log(hash_including(
+    expect(Pliny).to receive(:log)
+    expect(Pliny).to receive(:log).with(hash_including(
       status: 404
     ))
     get "/error"

--- a/spec/middleware/request_store_spec.rb
+++ b/spec/middleware/request_store_spec.rb
@@ -14,12 +14,12 @@ describe Pliny::Middleware::RequestStore do
   end
 
   it "clears the store" do
-    mock(Pliny::RequestStore).clear!
+    expect(Pliny::RequestStore).to receive(:clear!)
     get "/"
   end
 
   it "seeds the store" do
-    mock(Pliny::RequestStore).seed.with_any_args
+    expect(Pliny::RequestStore).to receive(:seed)
     get "/"
   end
 end

--- a/spec/middleware/rescue_errors_spec.rb
+++ b/spec/middleware/rescue_errors_spec.rb
@@ -28,7 +28,7 @@ describe Pliny::Middleware::RescueErrors do
 
   it "intercepts exceptions and renders" do
     @app = new_rack_app
-    mock(Pliny::ErrorReporter).notify.with_any_args
+    expect(Pliny::ErrorReporter).to receive(:notify)
     get "/"
     assert_equal 500, last_response.status
     error_json = MultiJson.decode(last_response.body)

--- a/spec/middleware/versioning_spec.rb
+++ b/spec/middleware/versioning_spec.rb
@@ -5,7 +5,6 @@ describe Pliny::Middleware::Versioning do
   before do
     @io = StringIO.new
     Pliny.stdout = @io
-    stub(@io).print
   end
 
   def app

--- a/spec/rollbar_logger_spec.rb
+++ b/spec/rollbar_logger_spec.rb
@@ -7,7 +7,7 @@ describe Pliny::RollbarLogger do
   let(:log_context) { { rollbar: true, level: level, message: message } }
 
   before do
-    mock(Pliny).log(log_context)
+    expect(Pliny).to receive(:log).with(log_context)
   end
 
   context '#debug' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
   config.include Rack::Test::Methods
 
   config.expect_with :minitest
-  config.mock_with :rr
+  config.mock_with :rspec
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
Previously, one could use Pliny with no error tracker or other error
trackers, but in 0.17.0 requiring Pliny will crash if one has removed
Rollbar.

To fix this, use a conditional class definition to fix this.


Incidentally, I'm still testing this out, but running the specs is broken from missing mocking symbols, per #273...so I'm abusing the Travis buildfarm to test.