### PR TITLE
Allow handler to specify custom message for uncaught errors

### DIFF
--- a/lib/pliny/middleware/rescue_errors.rb
+++ b/lib/pliny/middleware/rescue_errors.rb
@@ -3,6 +3,7 @@ module Pliny::Middleware
     def initialize(app, options = {})
       @app = app
       @raise = options[:raise]
+      @message = options[:message]
     end
 
     def call(env)
@@ -13,7 +14,7 @@ module Pliny::Middleware
       raise if @raise
 
       Pliny::ErrorReporters.notify(e, rack_env: env)
-      Pliny::Errors::Error.render(Pliny::Errors::InternalServerError.new)
+      Pliny::Errors::Error.render(Pliny::Errors::InternalServerError.new(@message))
     end
   end
 end

--- a/spec/middleware/rescue_errors_spec.rb
+++ b/spec/middleware/rescue_errors_spec.rb
@@ -43,12 +43,22 @@ describe Pliny::Middleware::RescueErrors do
     end
   end
 
+  it "uses a custom error message with the message option" do
+    @app = new_rack_app(message: "Please stand by")
+    allow(Pliny::ErrorReporters).to receive(:notify)
+    get "/"
+    assert_equal 500, last_response.status
+    error_json = MultiJson.decode(last_response.body)
+    assert_equal "internal_server_error", error_json["id"]
+    assert_equal "Please stand by", error_json["message"]
+  end
+
   private
 
   def new_rack_app(options = {})
     Rack::Builder.new do
       use Rack::Lint
-      use Pliny::Middleware::RescueErrors, raise: options[:raise]
+      use Pliny::Middleware::RescueErrors, raise: options[:raise], message: options[:message]
       run BadMiddleware.new
     end
   end


### PR DESCRIPTION
Thoughts on this? I know I should handle all potential errors explicitly, but if something sneaks through, it'd be nice to provide a more friendly message than "Internal server error."
