### PR TITLE
Clear request store before logging request

### DIFF
--- a/lib/template/lib/routes.rb
+++ b/lib/template/lib/routes.rb
@@ -1,9 +1,9 @@
 Routes = Rack::Builder.new do
   use Pliny::Middleware::CORS
   use Pliny::Middleware::RequestID
+  use Pliny::Middleware::RequestStore, store: Pliny::RequestStore
   use Pliny::Middleware::Instruments
   use Pliny::Middleware::RescueErrors, raise: Config.raise_errors?
-  use Pliny::Middleware::RequestStore, store: Pliny::RequestStore
   use Rack::Timeout,
       service_timeout: Config.timeout if Config.timeout > 0
   use Pliny::Middleware::Versioning,


### PR DESCRIPTION
While debugging an issue the other day, I noticed that the `Pliny::Middleware::Instruments` was logging out the `log_context` from a previous request. Diving further into it, it occurs because of ordering of loading middleware. There are two solutions that quickly come to mind to address this issue:

1. Re-ordering the middlewares so `Pliny::Middleware::RequestStore` runs before `::Instruments`. This is what this PR does and is the simplest solution. There are currently two middlewares before `::RequestStore`, mainly as this middleware has a dependency on the `::RequestId` middleware. The downside here is that if any of the earlier middlewares start using logging, we're in the same spot as before.

2. Split the `::RequestStore` middleware into two. `::RequestStore::Clear`, which would be the very first middleware and `::RequestStore::Seed` which would be loaded after any dependencies. This is what the Heroku API currently does. This means introducing breaking change, but given the importance of fixing this, I'm ok with.

I'd appreciate advisement on this.