### PR TITLE
Replace PLINY_ENV with APP_ENV

### DIFF
--- a/lib/pliny/config_helpers.rb
+++ b/lib/pliny/config_helpers.rb
@@ -50,19 +50,21 @@ module Pliny
     end
 
     def rack_env
-      if app_env == "development" || app_env == "test"
+      if env == "development" || env == "test"
         "development"
       else
         "deployment"
       end
     end
-    
-    # DEPRECATED: PLINY_ENV is deprecated in favour of APP_ENV.
+
+    # DEPRECATED: pliny_env is deprecated in favour of app_env.
     #             See more at https://github.com/interagent/pliny/issues/277
+    #
+    # This method is kept temporary in case it is used somewhere in the app.
     def pliny_env
       warn "Config.pliny_env is deprecated and will be removed, " \
            "use Config.app_env instead."
-      app_env
+      env
     end
 
     private
@@ -76,6 +78,20 @@ module Pliny
       instance_eval "def #{name}; @#{name} end", __FILE__, __LINE__
       if value.kind_of?(TrueClass) || value.kind_of?(FalseClass) || value.kind_of?(NilClass)
         instance_eval "def #{name}?; !!@#{name} end", __FILE__, __LINE__
+      end
+    end
+
+    # This method helps with transition from PLINY_ENV to APP_ENV.
+    def env
+      legacy_env || app_env
+    end
+
+    # PLINY_ENV is deprecated, but it might be still used by someone.
+    def legacy_env
+      if ENV.key?('PLINY_ENV')
+        warn "PLINY_ENV is deprecated in favour of APP_ENV, " \
+             "update .env file or application configuration."
+        ENV['PLINY_ENV']
       end
     end
   end

--- a/lib/pliny/config_helpers.rb
+++ b/lib/pliny/config_helpers.rb
@@ -50,11 +50,19 @@ module Pliny
     end
 
     def rack_env
-      if pliny_env == "development" || pliny_env == "test"
+      if app_env == "development" || app_env == "test"
         "development"
       else
         "deployment"
       end
+    end
+    
+    # DEPRECATED: PLINY_ENV is deprecated in favour of APP_ENV.
+    #             See more at https://github.com/interagent/pliny/issues/277
+    def pliny_env
+      warn "Config.pliny_env is deprecated and will be removed, " \
+           "use Config.app_env instead."
+      app_env
     end
 
     private

--- a/lib/template/.env.sample.erb
+++ b/lib/template/.env.sample.erb
@@ -1,7 +1,7 @@
 APP_NAME=<%= app_name %>
 DATABASE_URL=postgres:///<%= app_name %>-development
 DEPLOYMENT=development
-PLINY_ENV=development
+APP_ENV=development
 TZ=UTC
 RAISE_ERRORS=true
 FORCE_SSL=false

--- a/lib/template/.env.test.erb
+++ b/lib/template/.env.test.erb
@@ -1,7 +1,7 @@
 APP_NAME=<%= app_name %>
 DATABASE_URL=postgres:///<%= app_name %>-test
 DEPLOYMENT=test
-PLINY_ENV=test
+APP_ENV=test
 TZ=UTC
 RAISE_ERRORS=true
 FORCE_SSL=false

--- a/lib/template/app.json.erb
+++ b/lib/template/app.json.erb
@@ -5,7 +5,7 @@
   "env": {
     "APP_NAME": "<%= app_name %>",
     "DEPLOYMENT": "production",
-    "PLINY_ENV": "production"
+    "APP_ENV": "production"
   },
 
   "scripts": {

--- a/lib/template/config/config.rb
+++ b/lib/template/config/config.rb
@@ -22,7 +22,7 @@ module Config
   override :db_pool,          5,            int
   override :deployment,       'production', string
   override :force_ssl,        true,         bool
-  override :pliny_env,        'production', string
+  override :app_env,          'production', string
   override :port,             5000,         int
   override :pretty_json,      false,        bool
   override :puma_max_threads, 16,           int

--- a/spec/config_helpers_spec.rb
+++ b/spec/config_helpers_spec.rb
@@ -59,7 +59,7 @@ describe Pliny::CastingConfigHelpers do
         ENV['PLINY_ENV'] = ENV.delete('ORIGINAL_PLINY_ENV')
       end
 
-      it "uses PLINY_ENV value instead of app_env" do
+      it "uses PLINY_ENV value instead of APP_ENV" do
         config = Class.new do
           extend Pliny::CastingConfigHelpers
           override :app_env, 'development', string
@@ -106,6 +106,26 @@ describe Pliny::CastingConfigHelpers do
       end
 
       assert_equal "foo", config.pliny_env
+    end
+
+    context "when legacy PLINY_ENV is still defined" do
+      before do
+        ENV['ORIGINAL_PLINY_ENV'] = ENV['PLINY_ENV']
+        ENV['PLINY_ENV'] = 'staging'
+      end
+
+      after do
+        ENV['PLINY_ENV'] = ENV.delete('ORIGINAL_PLINY_ENV')
+      end
+
+      it "returns PLINY_ENV value" do
+        config = Class.new do
+          extend Pliny::CastingConfigHelpers
+          override :app_env, 'development', string
+        end
+
+        assert_equal "staging", config.pliny_env
+      end
     end
   end
 end

--- a/spec/config_helpers_spec.rb
+++ b/spec/config_helpers_spec.rb
@@ -4,49 +4,74 @@ require "pliny/config_helpers"
 describe Pliny::CastingConfigHelpers do
 
   describe "#rack_env" do
-    it "is development if pliny_env is development" do
+    it "is development if app_env is development" do
       config = Class.new do
         extend Pliny::CastingConfigHelpers
-        override :pliny_env, 'development', string
+        override :app_env, 'development', string
       end
 
       assert_equal "development", config.rack_env
     end
 
-    it "is development if pliny_env is test" do
+    it "is development if app_env is test" do
       config = Class.new do
         extend Pliny::CastingConfigHelpers
-        override :pliny_env, 'test', string
+        override :app_env, 'test', string
       end
 
       assert_equal "development", config.rack_env
     end
 
-    it "is deployment if pliny_env is production" do
+    it "is deployment if app_env is production" do
       config = Class.new do
         extend Pliny::CastingConfigHelpers
-        override :pliny_env, 'production', string
+        override :app_env, 'production', string
       end
 
       assert_equal "deployment", config.rack_env
     end
 
-    it "is deployment if pliny_env is nil" do
+    it "is deployment if app_env is nil" do
       config = Class.new do
         extend Pliny::CastingConfigHelpers
-        override :pliny_env, '', string
+        override :app_env, '', string
       end
 
       assert_equal "deployment", config.rack_env
     end
 
-    it "is deployment if pliny_env is another value" do
+    it "is deployment if app_env is another value" do
       config = Class.new do
         extend Pliny::CastingConfigHelpers
-        override :pliny_env, 'staging', string
+        override :app_env, 'staging', string
       end
 
       assert_equal "deployment", config.rack_env
+    end
+  end
+
+  describe "#pliny_env" do
+    it "displays deprecation warning if pliny_env is used" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :app_env, 'development', string
+      end
+
+      io = StringIO.new
+      $stderr = io
+      config.pliny_env
+      $stderr = STDERR
+
+      assert_includes io.string, "Config.pliny_env is deprecated"
+    end
+
+    it "returns app_env value" do
+      config = Class.new do
+        extend Pliny::CastingConfigHelpers
+        override :app_env, 'foo', string
+      end
+
+      assert_equal "foo", config.pliny_env
     end
   end
 end

--- a/spec/config_helpers_spec.rb
+++ b/spec/config_helpers_spec.rb
@@ -48,6 +48,40 @@ describe Pliny::CastingConfigHelpers do
 
       assert_equal "deployment", config.rack_env
     end
+
+    context "when legacy PLINY_ENV is still defined" do
+      before do
+        ENV['ORIGINAL_PLINY_ENV'] = ENV['PLINY_ENV']
+        ENV['PLINY_ENV'] = 'staging'
+      end
+
+      after do
+        ENV['PLINY_ENV'] = ENV.delete('ORIGINAL_PLINY_ENV')
+      end
+
+      it "uses PLINY_ENV value instead of app_env" do
+        config = Class.new do
+          extend Pliny::CastingConfigHelpers
+          override :app_env, 'development', string
+        end
+
+        assert_equal "deployment", config.rack_env
+      end
+
+      it "displays deprecation warning" do
+        config = Class.new do
+          extend Pliny::CastingConfigHelpers
+          override :app_env, 'development', string
+        end
+
+        io = StringIO.new
+        $stderr = io
+        config.rack_env
+        $stderr = STDERR
+
+        assert_includes io.string, "PLINY_ENV is deprecated"
+      end
+    end
   end
 
   describe "#pliny_env" do


### PR DESCRIPTION
Resolves https://github.com/interagent/pliny/issues/277.

`PLINY_ENV` and `pliny_env` have been replaced with `APP_ENV` and `app_env` everywhere in the code.

In order to help with transition, a deprecation message is displayed if `Config.pliny_env` is used. So `pliny_env` is actually deprecated and can be still called with a grumpy message. Deprecation message is based on [the pattern used in Sinatra](https://github.com/sinatra/sinatra/blob/1b0edc0aeaaf4839cadfcec1b21da86e6af1d4c0/lib/sinatra/base.rb#L945).

Would be happy to hear your thoughts on this one 😄 