### PR TITLE
Fix copy-paste mistake

### DIFF
--- a/spec/helpers/serialize_spec.rb
+++ b/spec/helpers/serialize_spec.rb
@@ -12,7 +12,7 @@ describe Pliny::Helpers::Serialize do
       end
     end
 
-    it "sets the Content-Type" do
+    it "raises a runtime error" do
       assert_raises(RuntimeError) do
         get "/"
       end


### PR DESCRIPTION
I guess the wrong example description has been copied by mistake from [here](https://github.com/interagent/pliny/blob/6e456f25e24a0dfe8be02c31505519246c8508b0/spec/helpers/encode_spec.rb#L17).

Thank you for doing great job! 😄 