### PR TITLE
Don't allow to require inexistent path

### DIFF
--- a/lib/pliny/utils.rb
+++ b/lib/pliny/utils.rb
@@ -19,6 +19,8 @@ module Pliny
         [file.count("/"), file]
       end
 
+      raise LoadError, "empty glob path: #{path}" if files.empty?
+
       files.each do |file|
         require file
       end

--- a/lib/template/lib/initializer.rb
+++ b/lib/template/lib/initializer.rb
@@ -29,7 +29,7 @@ module Initializer
   end
 
   def self.require_initializers
-    Pliny::Utils.require_glob("#{Config.root}/config/initializers/*.rb")
+    require!("config/initializers/*")
   end
 
   def self.require!(globs)


### PR DESCRIPTION
This change how Pliny require files, and do not allow to look for an inexistent path.
This avoid path bloat in the app initializer.