### PR TITLE
Pliny::Metrics.measure value argument

### DIFF
--- a/lib/pliny/metrics.rb
+++ b/lib/pliny/metrics.rb
@@ -24,7 +24,7 @@ module Pliny
       measurement =
         if opts.has_key?(:value)
           opts[:value]
-        elsif !elapsed.nil?
+        elsif block
           elapsed
         else
           0
@@ -36,7 +36,7 @@ module Pliny
         report_and_catch { backend.report_measures(measures) }
       end
 
-      return_value
+      block ? return_value : measures
     end
 
     private

--- a/lib/pliny/metrics.rb
+++ b/lib/pliny/metrics.rb
@@ -16,9 +16,21 @@ module Pliny
       counts
     end
 
-    def measure(*names, &block)
-      elapsed, return_value = time_elapsed(&block)
-      measures = Hash[names.map { |n| ["#{Config.app_name}.#{n}", elapsed] }]
+    def measure(*names, **opts, &block)
+      if block
+        elapsed, return_value = time_elapsed(&block)
+      end
+
+      measurement =
+        if opts.has_key?(:value)
+          opts[:value]
+        elsif !elapsed.nil?
+          elapsed
+        else
+          0
+        end
+
+      measures = Hash[names.map { |n| ["#{Config.app_name}.#{n}", measurement] }]
 
       backends.each do |backend|
         report_and_catch { backend.report_measures(measures) }

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -52,14 +52,14 @@ describe Pliny::Metrics do
       Pliny::Metrics.backends = [test_backend]
     end
 
-    it "measures a single key" do
+    it "measures a block's execution time with a single key" do
       metrics.measure(:foo) { }
       expect(test_backend).to have_received(:report_measures).once.with(
         "pliny.foo" => 0
       )
     end
 
-    it "measures a single key over a minute" do
+    it "measures a long block's execution time with a single key" do
       metrics.measure(:foo) do
         Timecop.travel(60)
       end
@@ -69,11 +69,33 @@ describe Pliny::Metrics do
       end
     end
 
-    it "measures multiple keys" do
+    it "measures a block's execution time with multiple keys" do
       metrics.measure(:foo, :bar) { }
       expect(test_backend).to have_received(:report_measures).once.with(
         "pliny.foo" => 0,
         "pliny.bar" => 0
+      )
+    end
+
+    it "measures a given value for a single key without a block" do
+      metrics.measure(:baz, value: 3.14)
+      expect(test_backend).to have_received(:report_measures).once.with(
+        "pliny.baz" => 3.14
+      )
+    end
+
+    it "measures a given value for multiple keys with a block" do
+      metrics.measure(:qux, :corge, value: 42) { }
+      expect(test_backend).to have_received(:report_measures).once.with(
+        "pliny.qux" => 42,
+        "pliny.corge" => 42
+      )
+    end
+
+    it "measures a value of 0 when no key or block is provided" do
+      metrics.measure(:waldo)
+      expect(test_backend).to have_received(:report_measures).once.with(
+        "pliny.waldo" => 0
       )
     end
   end


### PR DESCRIPTION
Many times, the operation you want to measure is not block execution time. You may want to measure something that is already stored as a variable. This is a common pattern for us, and we commonly do this:

```ruby
      queue = ::Sidekiq::Queue.new

      Pliny.log(
        "app.sidekiq.latency" => queue.latency,
        "app.sidekiq.depth" => queue.depth
      )
```

You can see here that we're leaning on l2met logging, but with the new pluggable metrics backends, it'd be much nicer to be able to do something like:

```ruby
Pliny::Metrics.measure("app.sidekiq.latency", queue.latency)
```

Right now, `measure` only reports execution time of the provided block. This PR proposes that the block becomes optional and if provided, the `:value` option takes precedence.

This should provide a symmetry between the two methods, e.g.:

```ruby
Pliny::Metrics.count(:foo, value: 3)
Pliny::Metrics.measure(:bar, value: 3.14)
```

But should also maintain the current API of:

```ruby
Pliny::Metrics.measure(:qux) { # some long running work }
```