### PR TITLE
Handle an empty rack_env in rollbar reporter

### DIFF
--- a/lib/pliny/error_reporters/rollbar.rb
+++ b/lib/pliny/error_reporters/rollbar.rb
@@ -18,9 +18,11 @@ module Pliny
       private
 
       def fetch_scope(context:, rack_env:)
-        {
-          request: proc { extract_request_data_from_rack(rack_env) }
-        }
+        scope = {}
+        if rack_env.respond_to?(:body)
+          scope[:request] = proc { extract_request_data_from_rack(rack_env) }
+        end
+        scope
       rescue Exception => e
         report_exception_to_rollbar(rack_env, e)
         raise

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+require "rollbar"
+require "pliny/error_reporters/rollbar"
+
+describe Pliny::ErrorReporters::Rollbar do
+  subject(:reporter) { described_class.new }
+
+  describe "#notify" do
+    let(:exception) { StandardError.new("Something went wrong") }
+    let(:context)   { {} }
+    let(:rack_env)  { double(:rack_env, body: StringIO.new) }
+
+    subject(:notify) do
+      reporter.notify(exception, context: context, rack_env: rack_env)
+    end
+
+    before do
+      allow(::Rollbar).to receive(:reset_notifier!)
+      allow(::Rollbar).to receive(:scoped).and_yield
+      allow(reporter).to receive(:report_exception_to_rollbar)
+    end
+
+    it "resets the rollbar notifier" do
+      notify
+      expect(::Rollbar).to have_received(:reset_notifier!).once
+    end
+
+    it "scopes the rollbar notification" do
+      notify
+      expect(::Rollbar).to have_received(:scoped).once.with(hash_including(
+        request: instance_of(Proc)
+      ))
+    end
+
+    it "delegates to #report_exception_to_rollbar" do
+      notify
+      expect(reporter).to have_received(:report_exception_to_rollbar)
+        .once.with(rack_env, exception)
+    end
+
+    context "given an empty rack_env" do
+      let(:rack_env) { {} }
+
+      it "reports to Rollbar with an empty scope" do
+        notify
+        expect(Rollbar).to have_received(:scoped).once.with({})
+      end
+
+      it "delegates to #report_exception_to_rollbar" do
+        notify
+        expect(reporter).to have_received(:report_exception_to_rollbar)
+          .once.with(rack_env, exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the `error_reporter` we default to an empty hash for `rack_env`, but if that is passed to rollbar it results in an exception like:

```
NoMethodError: "undefined method `rewind' for nil:NilClass" in /app/vendor/bundle/ruby/2.3.0/gems/rollbar-2.11.3/lib/rollbar/request_data_extractor.rb:157:in `rollbar_raw_body_params': build_item in exception_data
```

That's because we call the `#extract_request_data_from_rack` method which expects a fully formed rack env to be passed. I hit this error when trying to use the Pliny error reporter from outside of a rack request context.

This change removes the request scoping if no rack env was passed.