### PR TITLE
Add "pry-byebug" to Pliny

### DIFF
--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "sinatra-contrib", "~> 1.4", ">= 1.4.7"
   gem.add_development_dependency "timecop", "~> 0.7", ">= 0.7.1"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "pry-byebug"
   gem.add_development_dependency "pg",      "~> 0.17", ">= 0.17.1"
   gem.add_development_dependency "rollbar", "~> 2.11", ">= 2.11.0"
   gem.add_development_dependency "sequel",  "~> 4.9",  ">= 4.9.0"


### PR DESCRIPTION
Adds "pry-byebug" to the main Pliny project as a development dependency.
Pry can be invoked already, but it's not a whole bunch of use without a
debugger.