### PR TITLE
Fix rollbar scope extraction

### DIFF
--- a/lib/pliny/error_reporters/rollbar.rb
+++ b/lib/pliny/error_reporters/rollbar.rb
@@ -19,7 +19,7 @@ module Pliny
 
       def fetch_scope(context:, rack_env:)
         scope = {}
-        if rack_env.respond_to?(:body)
+        if rack_env.has_key?("rack.input")
           scope[:request] = proc { extract_request_data_from_rack(rack_env) }
         end
         scope

--- a/lib/pliny/error_reporters/rollbar.rb
+++ b/lib/pliny/error_reporters/rollbar.rb
@@ -19,7 +19,7 @@ module Pliny
 
       def fetch_scope(context:, rack_env:)
         scope = {}
-        if rack_env.has_key?("rack.input")
+        unless rack_env.empty?
           scope[:request] = proc { extract_request_data_from_rack(rack_env) }
         end
         scope

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -41,6 +41,10 @@ describe Pliny::ErrorReporters::Rollbar do
     context "given an empty rack_env" do
       let(:rack_env) { {} }
 
+      it "expects rack_env to be a hash" do
+        assert_kind_of(Hash, rack_env)
+      end
+
       it "reports to Rollbar with an empty scope" do
         notify
         expect(Rollbar).to have_received(:scoped).once.with({})

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -8,7 +8,7 @@ describe Pliny::ErrorReporters::Rollbar do
   describe "#notify" do
     let(:exception) { StandardError.new("Something went wrong") }
     let(:context)   { {} }
-    let(:rack_env)  { double(:rack_env, body: StringIO.new) }
+    let(:rack_env)  { { "rack.input" => StringIO.new } }
 
     subject(:notify) do
       reporter.notify(exception, context: context, rack_env: rack_env)


### PR DESCRIPTION
A rack env is a simple hash and as such will never respond to the method `body`. It does however have a key of `rack.input`. Maybe there is some confusion around what is being passed into `notify`... `env` vs `Rack::Request.new(env)`?

/cc @appleton 
ref https://github.com/interagent/pliny/pull/291