### PR TITLE
Include custom data in scope sent to rollbar

### DIFF
--- a/lib/pliny/error_reporters/rollbar.rb
+++ b/lib/pliny/error_reporters/rollbar.rb
@@ -18,7 +18,7 @@ module Pliny
       private
 
       def fetch_scope(context:, rack_env:)
-        scope = {}
+        scope = { custom: context }
         unless rack_env.empty?
           scope[:request] = proc { extract_request_data_from_rack(rack_env) }
         end

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -7,7 +7,7 @@ describe Pliny::ErrorReporters::Rollbar do
 
   describe "#notify" do
     let(:exception) { StandardError.new("Something went wrong") }
-    let(:context)   { {} }
+    let(:context)   { { step: :foo } }
     let(:rack_env)  { { "rack.input" => StringIO.new } }
 
     subject(:notify) do
@@ -28,7 +28,8 @@ describe Pliny::ErrorReporters::Rollbar do
     it "scopes the rollbar notification" do
       notify
       expect(::Rollbar).to have_received(:scoped).once.with(hash_including(
-        request: instance_of(Proc)
+        request: instance_of(Proc),
+        custom: { step: :foo }
       ))
     end
 
@@ -45,9 +46,9 @@ describe Pliny::ErrorReporters::Rollbar do
         assert_kind_of(Hash, rack_env)
       end
 
-      it "reports to Rollbar with an empty scope" do
+      it "reports to Rollbar without request data in the scope" do
         notify
-        expect(Rollbar).to have_received(:scoped).once.with({})
+        expect(Rollbar).to have_received(:scoped).once.with({ custom: {step: :foo} })
       end
 
       it "delegates to #report_exception_to_rollbar" do


### PR DESCRIPTION
This includes the provided context in the rollbar scope. Previously the context was ignored and not included in the scope. This is similar to how scope is defined for rails in rollbar: https://rollbar.com/docs/notifier/rollbar-gem/#the-scope