### PR TITLE
Fix Travis and canonical log lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 2.2.2
 addons:
   postgresql: '9.3'
+before_install:
+  - gem update --system
 before_script:
   - createdb pliny-gem-test
 sudo: false

--- a/lib/template/lib/routes.rb
+++ b/lib/template/lib/routes.rb
@@ -6,7 +6,7 @@ Routes = Rack::Builder.new do
   use Pliny::Middleware::Metrics
   use Pliny::Middleware::CanonicalLogLine,
       emitter: -> (data) {
-        Pliny.log_without_context({ canonical_log_line: true }.merge(data)
+        Pliny.log_without_context({ canonical_log_line: true }.merge(data))
       }
   use Pliny::Middleware::RescueErrors, raise: Config.raise_errors?
   if Config.timeout.positive?


### PR DESCRIPTION
While cutting a new release of Pliny, I noticed that the last two PRs we've merged introduced errors.

* The rainbow gem fails to build with the system version of RubyGems.
* A missing `)` in `routes.rb` causes failure to start.