### PR TITLE
Add arity and timings for serializers to canonical log lines

### DIFF
--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -14,11 +14,11 @@ No serializer has been specified for this endpoint. Please specify one with
         eos
       end
 
-      env['serialization_arity'] = data.respond_to?(:size) ? data.size : 1
+      env['pliny.serialization_arity'] = data.respond_to?(:size) ? data.size : 1
 
       start = Time.now
       serializer_class.new(structure).serialize(data).tap do
-        env['timing_serialization'] = (Time.now - start).to_f
+        env['pliny.serialization_timing'] = (Time.now - start).to_f
       end
     end
 

--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -5,14 +5,21 @@ module Pliny::Helpers
     end
 
     def serialize(data, structure = :default)
-      if self.class.serializer_class.nil?
+      serializer_class = self.class.serializer_class
+
+      if serializer_class.nil?
         raise <<-eos.strip
 No serializer has been specified for this endpoint. Please specify one with
 `serializer Serializers::ModelName` in the endpoint.
         eos
       end
 
-      self.class.serializer_class.new(structure).serialize(data)
+      env['serialization_arity'] = data.respond_to?(:size) ? data.size : 1
+
+      start = Time.now
+      serializer_class.new(structure).serialize(data).tap do
+        env['timing_serialization'] = (Time.now - start).to_f
+      end
     end
 
     module ClassMethods

--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -14,11 +14,11 @@ No serializer has been specified for this endpoint. Please specify one with
         eos
       end
 
-      env['pliny.serialization_arity'] = data.respond_to?(:size) ? data.size : 1
+      env['pliny.serializer_arity'] = data.respond_to?(:size) ? data.size : 1
 
       start = Time.now
       serializer_class.new(structure).serialize(data).tap do
-        env['pliny.serialization_timing'] = (Time.now - start).to_f
+        env['pliny.serializer_timing'] = (Time.now - start).to_f
       end
     end
 

--- a/lib/pliny/middleware/canonical_log_line.rb
+++ b/lib/pliny/middleware/canonical_log_line.rb
@@ -105,14 +105,14 @@ module Pliny::Middleware
             line.response_length = length.to_i
           end
           line.response_status = status
-          line.serialization_arity = env["serialization_arity"]
+          line.serialization_arity = env["pliny.serialization_arity"]
 
           #
           # timing
           #
 
           line.timing_total_elapsed = (Time.now - start).to_f
-          line.timing_serialization = env["timing_serialization"]
+          line.timing_serialization = env["pliny.serialization_timing"]
 
           @emitter.call(line.to_h)
         rescue => e

--- a/lib/pliny/middleware/canonical_log_line.rb
+++ b/lib/pliny/middleware/canonical_log_line.rb
@@ -48,12 +48,14 @@ module Pliny::Middleware
 
       log_field :response_length, Integer
       log_field :response_status, Integer
+      log_field :serialization_arity, Integer
 
       #
       # timing
       #
 
       log_field :timing_total_elapsed, Float
+      log_field :timing_serialization, Float
     end
 
     def initialize(app, emitter:)
@@ -103,12 +105,14 @@ module Pliny::Middleware
             line.response_length = length.to_i
           end
           line.response_status = status
+          line.serialization_arity = env["serialization_arity"]
 
           #
           # timing
           #
 
           line.timing_total_elapsed = (Time.now - start).to_f
+          line.timing_serialization = env["timing_serialization"]
 
           @emitter.call(line.to_h)
         rescue => e

--- a/lib/pliny/middleware/canonical_log_line.rb
+++ b/lib/pliny/middleware/canonical_log_line.rb
@@ -48,14 +48,14 @@ module Pliny::Middleware
 
       log_field :response_length, Integer
       log_field :response_status, Integer
-      log_field :serialization_arity, Integer
+      log_field :serializer_arity, Integer
 
       #
       # timing
       #
 
       log_field :timing_total_elapsed, Float
-      log_field :timing_serialization, Float
+      log_field :timing_serializer, Float
     end
 
     def initialize(app, emitter:)
@@ -105,14 +105,14 @@ module Pliny::Middleware
             line.response_length = length.to_i
           end
           line.response_status = status
-          line.serialization_arity = env["pliny.serialization_arity"]
+          line.serializer_arity = env["pliny.serializer_arity"]
 
           #
           # timing
           #
 
           line.timing_total_elapsed = (Time.now - start).to_f
-          line.timing_serialization = env["pliny.serialization_timing"]
+          line.timing_serializer = env["pliny.serializer_timing"]
 
           @emitter.call(line.to_h)
         rescue => e

--- a/spec/helpers/serialize_spec.rb
+++ b/spec/helpers/serialize_spec.rb
@@ -44,5 +44,9 @@ describe Pliny::Helpers::Serialize do
       assert_equal 200, last_response.status
       assert_equal MultiJson.encode([]), last_response.body
     end
+
+    it "measures time for serialiation" do
+      get "/"
+    end
   end
 end

--- a/spec/helpers/serialize_spec.rb
+++ b/spec/helpers/serialize_spec.rb
@@ -36,6 +36,10 @@ describe Pliny::Helpers::Serialize do
         get "/" do
           MultiJson.encode(serialize([]))
         end
+
+        get "/env" do
+          MultiJson.encode(serialize(env))
+        end
       end
     end
 
@@ -45,8 +49,12 @@ describe Pliny::Helpers::Serialize do
       assert_equal MultiJson.encode([]), last_response.body
     end
 
-    it "measures time for serialiation" do
-      get "/"
+    it "emits information for canonical log lines" do
+      get "/env"
+      assert_equal 200, last_response.status
+      body = MultiJson.decode(last_response.body)
+      assert body["pliny.serializer_arity"] > 1
+      assert body["pliny.serializer_timing"] > 0
     end
   end
 end


### PR DESCRIPTION
This change adds `serialization_arity` and `timing_serialization` to the canonical log line. I find it a little strange storing this in `env[]`, but don't really have better suggestions.