### PR TITLE
By default, log canonical lines with just default context

### DIFF
--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -4,6 +4,10 @@ module Pliny
       log_to_stream(stdout || $stdout, merge_log_contexts(data), &block)
     end
 
+    def log_with_default_context(data, &block)
+      log_to_stream(stdout || $stdout, default_context.merge(data), &block)
+    end
+
     def log_without_context(data, &block)
       log_to_stream(stdout || $stdout, data, &block)
     end

--- a/lib/template/lib/routes.rb
+++ b/lib/template/lib/routes.rb
@@ -6,7 +6,7 @@ Routes = Rack::Builder.new do
   use Pliny::Middleware::Metrics
   use Pliny::Middleware::CanonicalLogLine,
       emitter: -> (data) {
-        Pliny.log_without_context({ canonical_log_line: true }.merge(data))
+        Pliny.log_with_default_context({ canonical_log_line: true }.merge(data))
       }
   use Pliny::Middleware::RescueErrors, raise: Config.raise_errors?
   if Config.timeout.positive?

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -38,6 +38,13 @@ describe Pliny::Log do
     Pliny.log(foo: "bar")
   end
 
+  it "logs with just default context" do
+    Pliny.default_context = { app: "pliny" }
+    Pliny::RequestStore.store[:log_context] = { request_store: true }
+    expect(@io).to receive(:print).with("app=pliny foo=bar\n")
+    Pliny.log_with_default_context(foo: "bar")
+  end
+
   it "logs without context" do
     Pliny.default_context = { app: "pliny" }
     expect(@io).to receive(:print).with("foo=bar\n")


### PR DESCRIPTION
In retrospect, it seems to make sense to log canonical lines with just
default logging context so that it'll include an app name and any other
information that a user has deemed critical. There is some trade off
here because the information included by the canonical logger becomes
less explicit, but that'll probably be okay.

cc @gudmundur Would you mind taking a look at this one? Thanks!