### PR TITLE
Add support for sinatra 2.0.0

### DIFF
--- a/lib/template/Gemfile
+++ b/lib/template/Gemfile
@@ -14,7 +14,7 @@ gem "rollbar"
 gem "sequel", "~> 4.34"
 gem "sequel-paranoid"
 gem "sequel_pg", "~> 1.6", require: "sequel"
-gem "sinatra", "~> 1.4", require: "sinatra/base"
+gem "sinatra", [">= 1.4", "< 3.0"], require: "sinatra/base"
 gem "sinatra-contrib", require: ["sinatra/namespace", "sinatra/reloader"]
 gem "sinatra-router"
 gem "sucker_punch"

--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -19,15 +19,16 @@ Gem::Specification.new do |gem|
   gem.add_dependency "multi_json",     "~> 1.9",  ">= 1.9.3"
   gem.add_dependency "prmd",           "~> 0.11", ">= 0.11.4"
 
-  gem.add_dependency "sinatra",        "~> 1.4",  ">= 1.4.7"
+
+  gem.add_dependency "sinatra",        ">= 1.4", "< 3.0"
   gem.add_dependency "http_accept",    "~> 0.1",  ">= 0.1.5"
-  gem.add_dependency "sinatra-router", "~> 0.2",  ">= 0.2.3"
+  gem.add_dependency "sinatra-router", "~> 0.2",  ">= 0.2.4"
   gem.add_dependency "thor",           "~> 0.19", ">= 0.19.1"
 
-  gem.add_development_dependency "rake", "~> 0.8", ">= 0.8.7"
-  gem.add_development_dependency "rack-test", "~> 0.6", ">= 0.6.2"
-  gem.add_development_dependency "rspec", "~> 3.1", ">= 3.1.0"
-  gem.add_development_dependency "sinatra-contrib", "~> 1.4", ">= 1.4.7"
+  gem.add_development_dependency "rake",              "~> 0.8", ">= 0.8.7"
+  gem.add_development_dependency "rack-test",         "~> 0.6", ">= 0.6.2"
+  gem.add_development_dependency "rspec",             "~> 3.1", ">= 3.1.0"
+  gem.add_development_dependency "sinatra-contrib",   ">= 1.4", "< 3.0"
   gem.add_development_dependency "timecop", "~> 0.7", ">= 0.7.1"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This allows using Sinatra 2.0.0, while also retaining support for 1.4.