### PR TITLE
Remove hipchat notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,5 @@ before_script:
 sudo: false
 cache: bundler
 notifications:
-  hipchat:
-    rooms:
-      - 5bc7785d2feb4f25901124279daede@API
-    template:
-      - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} (<a href="%{build_url}">Details</a> | <a href="%{compare_url}">Change view</a>)'
-    format: html
   email: false
 script: bundle exec rake


### PR DESCRIPTION
I believe this hipchat notification is from an internal Heroku channel.
Heroku isn't using hipchat anymore, so this probably goes nowhere.