### PR TITLE
Re-introduce the instruments middleware

### DIFF
--- a/lib/template/lib/routes.rb
+++ b/lib/template/lib/routes.rb
@@ -4,6 +4,7 @@ Routes = Rack::Builder.new do
   use Pliny::Middleware::RequestID
   use Pliny::Middleware::RequestStore::Seed, store: Pliny::RequestStore
   use Pliny::Middleware::Metrics
+  use Pliny::Middleware::Instruments
   use Pliny::Middleware::CanonicalLogLine,
       emitter: -> (data) {
         Pliny.log_with_default_context({ canonical_log_line: true }.merge(data))


### PR DESCRIPTION
With the introduction of canonical log lines, we dropped the `Pliny::Middleware::Instruments` as a default middleware, [see here](https://github.com/interagent/pliny/commit/106e7c050eeb8b029a4752d44763000729aff0a5). The side effect of that is that the start of a request is not logged. The default log lines emitted for a request are:

```
app=hello deployment=development request_id=c3ae2fae-0b29-4d27-9f05-402fcce7a95e count#hello.requests=1
app=hello deployment=development canonical_log_line request_id=c3ae2fae-0b29-4d27-9f05-402fcce7a95e request_ip=127.0.0.1 request_method=GET request_path=/ request_user_agent=curl/7.51.0 request_route_signature=/ response_length=6 response_status=200 timing_total_elapsed=0.033
app=hello deployment=development request_id=c3ae2fae-0b29-4d27-9f05-402fcce7a95e measure#hello.requests.latency=0.033
app=hello deployment=development request_id=c3ae2fae-0b29-4d27-9f05-402fcce7a95e count#hello.requests.status.2xx=1
app=hello deployment=development request_id=bdd42e63-005e-48b4-9d70-99698288c0e6 count#hello.requests=1
```

The initial `count#hello.requests=1` happens at the beginning of a request but is a metrics line, and will be dropped if a different metric backend than `logfmt` is used.

This change brings back the `Instruments` middleware, although much of the information reported by it is already available in the canonical log line. It does have the benefit of indicating the start and end of a request.