### PR TITLE
Use IndifferentHash class instead of method

### DIFF
--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -8,13 +8,22 @@ module Pliny::Helpers
 
     def parse_body_params
       if request.media_type == "application/json"
-        p = Sinatra::IndifferentHash[MultiJson.decode(request.body.read)]
+        p = load_params(MultiJson.decode(request.body.read))
         request.body.rewind
         p
       elsif request.form_data?
-        Sinatra::IndifferentHash[request.POST]
+        load_params(request.POST)
       else
         {}
+      end
+    end
+
+    def load_params(data)
+      # Sinatra 1.x only supports the method. Sinatra 2.x only supports the class
+      if respond_to?(:indifferent_params)
+        indifferent_params(data)
+      else
+        Sinatra::IndifferentHash[data]
       end
     end
   end

--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -8,11 +8,11 @@ module Pliny::Helpers
 
     def parse_body_params
       if request.media_type == "application/json"
-        p = indifferent_params(MultiJson.decode(request.body.read))
+        p = Sinatra::IndifferentHash[MultiJson.decode(request.body.read)]
         request.body.rewind
         p
       elsif request.form_data?
-        indifferent_params(request.POST)
+        Sinatra::IndifferentHash[request.POST]
       else
         {}
       end

--- a/spec/helpers/params_spec.rb
+++ b/spec/helpers/params_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe Pliny::Helpers::Params do
+
+  def app
+    Sinatra.new do
+      helpers Pliny::Helpers::Params
+      post "/" do
+        body_params.to_json
+      end
+    end
+  end
+
+  it "loads json params" do
+    post "/", {hello: "world"}.to_json, {'CONTENT_TYPE' => 'application/json'}
+    assert_equal "{\"hello\":\"world\"}", last_response.body
+  end
+
+  it "loads form data params" do
+    post "/", {hello: "world"}
+    assert_equal "{\"hello\":\"world\"}", last_response.body
+  end
+
+  it "loads from an unknown content type" do
+    post "/", "<hello>world</hello>", {'CONTENT_TYPE' => 'application/xml'}
+    assert_equal "{}", last_response.body
+  end
+end


### PR DESCRIPTION
The indifferent_params method doesn't exist anymore in Sinatra 2.0 (See https://github.com/sinatra/sinatra/commit/44c3cb89b7c9e26ce66e0e9bfe5a481fbef6fc22#diff-f2bc16b264ca20ca842cf15d82960d34 ).

cc @bigkevmcd