### PR TITLE
Check on the new class instead of the method

### DIFF
--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -20,10 +20,10 @@ module Pliny::Helpers
 
     def load_params(data)
       # Sinatra 1.x only supports the method. Sinatra 2.x only supports the class
-      if respond_to?(:indifferent_params)
-        indifferent_params(data)
-      else
+      if defined?(Sinatra::IndifferentHash)
         Sinatra::IndifferentHash[data]
+      else
+        indifferent_params(data)
       end
     end
   end


### PR DESCRIPTION
The `indifferent_params` method is defined as a class method for an included module. So it's callable, but returns false to `respond_with` 🤦‍♂️ .