### PR TITLE
Add mechanism for additional headers.

### DIFF
--- a/spec/middleware/cors_spec.rb
+++ b/spec/middleware/cors_spec.rb
@@ -39,4 +39,15 @@ describe Pliny::Middleware::CORS do
     assert_equal "http://localhost",
       last_response.headers["Access-Control-Allow-Origin"]
   end
+
+  it "allows additional headers to be added to every response" do
+    Pliny::Middleware::CORS.add_additional_header("X-Origin")
+
+    header "Origin", "http://localhost"
+    get "/"
+    assert_equal 200, last_response.status
+    assert_equal "hi", last_response.body
+
+    assert last_response.headers["Access-Control-Allow-Headers"].include?("X-Origin")
+  end
 end


### PR DESCRIPTION
To add additional headers to responses, we have to resort to something like...

```Ruby
allowed_cors_headers = Pliny::Middleware::CORS.send(:remove_const, :ALLOW_HEADERS).dup
allowed_cors_headers << "X-Origin"

Pliny::Middleware::CORS::ALLOW_HEADERS = allowed_cors_headers.freeze
```

It'd be nice if we could just configure the response headers globally when configuring our app?