### PR TITLE
Add "rollbar.person_data" to rollbar scope

### DIFF
--- a/lib/pliny/error_reporters/rollbar.rb
+++ b/lib/pliny/error_reporters/rollbar.rb
@@ -21,6 +21,7 @@ module Pliny
         scope = { custom: context }
         unless rack_env.empty?
           scope[:request] = proc { extract_request_data_from_rack(rack_env) }
+          scope[:person] = proc { extract_person_data_from_controller(rack_env) }
         end
         scope
       rescue Exception => e

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -34,14 +34,20 @@ describe Pliny::ErrorReporters::Rollbar do
     end
 
     context "given a rack_env with person data" do
-      let(:rack_env) { { "rollbar.person_data" => { email: "foo@bar.com" } } }
+      let(:rack_env) do
+        { "rollbar.person_data" => {
+          id: SecureRandom.uuid,
+          email: "foo@bar.com",
+          username: "foo"
+        }}
+      end
 
       it "adds person to the rollbar notification" do
         scope = nil
         allow(::Rollbar).to receive(:scoped) { |arg| scope = arg }
         notify
         assert_kind_of(Proc, scope[:person])
-        assert_equal({ email: "foo@bar.com" }, scope[:person].call)
+        assert_equal(rack_env["rollbar.person_data"], scope[:person].call)
       end
     end
 

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -37,10 +37,11 @@ describe Pliny::ErrorReporters::Rollbar do
       let(:rack_env) { { "rollbar.person_data" => { email: "foo@bar.com" } } }
 
       it "adds person to the rollbar notification" do
+        scope = nil
+        allow(::Rollbar).to receive(:scoped) { |arg| scope = arg }
         notify
-        expect(::Rollbar).to have_received(:scoped).once.with(hash_including(
-          person: instance_of(Proc)
-        ))
+        assert_kind_of(Proc, scope[:person])
+        assert_equal({ email: "foo@bar.com" }, scope[:person].call)
       end
     end
 

--- a/spec/error_reporters/rollbar_spec.rb
+++ b/spec/error_reporters/rollbar_spec.rb
@@ -33,6 +33,17 @@ describe Pliny::ErrorReporters::Rollbar do
       ))
     end
 
+    context "given a rack_env with person data" do
+      let(:rack_env) { { "rollbar.person_data" => { email: "foo@bar.com" } } }
+
+      it "adds person to the rollbar notification" do
+        notify
+        expect(::Rollbar).to have_received(:scoped).once.with(hash_including(
+          person: instance_of(Proc)
+        ))
+      end
+    end
+
     it "delegates to #report_exception_to_rollbar" do
       notify
       expect(reporter).to have_received(:report_exception_to_rollbar)


### PR DESCRIPTION
I was attempting to add the logged in user to my rollbar reports and setting the rack env data did not work.  It did when I used the default reporter and tracked the difference down to here https://github.com/rollbar/rollbar-gem/blob/master/lib/rollbar/middleware/rack.rb#L33 .  This just duplicates that functionality in the pliny reporter.  The test is a little clunky in that it tests some rollbar functionality, but I wanted to make sure that the person data is picked up correctly.