### PR TITLE
Sort by filename when generating INSERTs

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -107,7 +107,7 @@ begin
           search_path = db.dataset.with_sql("SHOW search_path").single_value
           schema << "SET search_path = #{search_path};\n\n"
 
-          db[:schema_migrations].each do |migration|
+          db[:schema_migrations].order_by(:filename).each do |migration|
             schema << db[:schema_migrations].insert_sql(migration) + ";\n"
           end
         end


### PR DESCRIPTION
Previously, the only thing keeping the output of .sql generation was
the insert order of tuples happening to the recall order...something
that can easily de-synchronize with multiple developers that may be
writing migrations at the same time.

Instead of getting the tuples in any order, sort them by their
content.