### PR TITLE
Handle a JSON Array of params

### DIFF
--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -21,9 +21,19 @@ module Pliny::Helpers
     def load_params(data)
       # Sinatra 1.x only supports the method. Sinatra 2.x only supports the class
       if defined?(Sinatra::IndifferentHash)
-        Sinatra::IndifferentHash[data]
+        indifferent_params_v2(data)
       else
         indifferent_params(data)
+      end
+    end
+
+    def indifferent_params_v2(data)
+      if data.respond_to?(:to_hash)
+        Sinatra::IndifferentHash[data.to_hash]
+      elsif data.respond_to?(:to_ary)
+        data.to_ary.map { |item| Sinatra::IndifferentHash[item] }
+      else
+        data
       end
     end
   end

--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -32,7 +32,7 @@ module Pliny::Helpers
       when Hash
         Sinatra::IndifferentHash[data]
       when Array
-        data.map { |item| Sinatra::IndifferentHash[item] }
+        data.map { |item| indifferent_params_v2(item) }
       else
         data
       end

--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -28,10 +28,11 @@ module Pliny::Helpers
     end
 
     def indifferent_params_v2(data)
-      if data.respond_to?(:to_hash)
-        Sinatra::IndifferentHash[data.to_hash]
-      elsif data.respond_to?(:to_ary)
-        data.to_ary.map { |item| Sinatra::IndifferentHash[item] }
+      case data
+      when Hash
+        Sinatra::IndifferentHash[data]
+      when Array
+        data.map { |item| Sinatra::IndifferentHash[item] }
       else
         data
       end

--- a/spec/helpers/params_spec.rb
+++ b/spec/helpers/params_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe Pliny::Helpers::Params do
-
   def app
     Sinatra.new do
       helpers Pliny::Helpers::Params
@@ -12,8 +11,13 @@ describe Pliny::Helpers::Params do
   end
 
   it "loads json params" do
-    post "/", {hello: "world"}.to_json, {'CONTENT_TYPE' => 'application/json'}
+    post "/", {hello: "world"}.to_json, {"CONTENT_TYPE" => "application/json"}
     assert_equal "{\"hello\":\"world\"}", last_response.body
+  end
+
+  it "loads json array of params" do
+    post "/", [{hello: "world"}, {goodbye: "moon"}].to_json, {"CONTENT_TYPE" => "application/json"}
+    assert_equal "[{\"hello\":\"world\"},{\"goodbye\":\"moon\"}]", last_response.body
   end
 
   it "loads form data params" do
@@ -22,7 +26,7 @@ describe Pliny::Helpers::Params do
   end
 
   it "loads from an unknown content type" do
-    post "/", "<hello>world</hello>", {'CONTENT_TYPE' => 'application/xml'}
+    post "/", "<hello>world</hello>", {"CONTENT_TYPE" => "application/xml"}
     assert_equal "{}", last_response.body
   end
 end

--- a/spec/helpers/params_spec.rb
+++ b/spec/helpers/params_spec.rb
@@ -20,6 +20,11 @@ describe Pliny::Helpers::Params do
     assert_equal "[{\"hello\":\"world\"},{\"goodbye\":\"moon\"}]", last_response.body
   end
 
+  it "loads json array of arrays of params" do
+    post "/", [[{hello: "world"}], [{goodbye: "moon"}]].to_json, {"CONTENT_TYPE" => "application/json"}
+    assert_equal "[[{\"hello\":\"world\"}],[{\"goodbye\":\"moon\"}]]", last_response.body
+  end
+
   it "loads form data params" do
     post "/", {hello: "world"}
     assert_equal "{\"hello\":\"world\"}", last_response.body


### PR DESCRIPTION
Back in #317 we started using `Sinatra::IndifferentHash` for Sinatra v2+, but didn't handle the case of a JSON array being passed as the root element. The older `#indifferent_params` from Sinatra v1 did handle this case. We've roughly re-created that here, though we're a little more permissive in that we allow for things that are Hash-like (via `#to_hash`) and Array-like (via `#to_ary`) rather than relying on type.