### PR TITLE
Test cleanup and consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+  - Ruby warning about `File.exists?` being deprecated. ([#330](https://github.com/interagent/pliny/pull/330))
 
 ## [0.27.1] - 2018-01-18
 ### Changed

--- a/lib/pliny/commands/updater.rb
+++ b/lib/pliny/commands/updater.rb
@@ -1,7 +1,7 @@
-require 'fileutils'
-require 'pathname'
-require 'pliny/version'
-require 'uri'
+require "fileutils"
+require "pathname"
+require "pliny/version"
+require "uri"
 
 module Pliny::Commands
   class Updater
@@ -37,7 +37,7 @@ module Pliny::Commands
 
     # we need a local copy of the pliny repo to produce a diff
     def ensure_repo_available
-      if File.exists?(repo_dir)
+      if File.exist?(repo_dir)
         unless system("cd #{repo_dir} && git fetch --tags")
           abort("Could not update Pliny repo at #{repo_dir}")
         end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -142,8 +142,6 @@ begin
           env_path = "./#{env_file}"
           if File.exist?(env_path)
             Pliny::Utils.parse_env(env_path)["DATABASE_URL"]
-          else
-            nil
           end
         }.compact
       end

--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -32,12 +32,12 @@ begin
 
     desc "Seed the database with data"
     task :seed do
-      if File.exist?('./db/seeds.rb')
+      if File.exist?("./db/seeds.rb")
         database_urls.each do |database_url|
           # make a DB instance available to the seeds file
-          self.class.send(:remove_const, 'DB') if self.class.const_defined?('DB')
-          self.class.const_set('DB', Sequel.connect(database_url))
-          load 'db/seeds.rb'
+          self.class.send(:remove_const, "DB") if self.class.const_defined?("DB")
+          self.class.const_set("DB", Sequel.connect(database_url))
+          load "db/seeds.rb"
         end
         disconnect
       end
@@ -66,7 +66,7 @@ begin
         admin_url = Pliny::DbSupport.admin_url(database_url)
         db = Sequel.connect(admin_url)
         name = name_from_uri(database_url)
-        db.run(%{DROP DATABASE IF EXISTS "#{name}"})
+        db.run(%(DROP DATABASE IF EXISTS "#{name}"))
         puts "Dropped `#{name}`"
       end
       disconnect
@@ -75,7 +75,7 @@ begin
     namespace :schema do
       desc "Load the database schema"
       task :load do
-        if File.exists?("./db/schema.sql")
+        if File.exist?("./db/schema.sql")
           schema = File.read("./db/schema.sql")
           database_urls.each do |database_url|
             db = Sequel.connect(database_url)
@@ -118,14 +118,14 @@ begin
       end
 
       desc "Merges migrations into schema and removes them"
-      task :merge => ["db:setup", "db:schema:dump"] do
+      task merge: ["db:setup", "db:schema:dump"] do
         FileUtils.rm Dir["./db/migrate/*.rb"]
         puts "Removed migrations"
       end
     end
 
     desc "Setup the database"
-    task :setup => [:drop, :create, "schema:load", :migrate, :seed]
+    task setup: [:drop, :create, "schema:load", :migrate, :seed]
 
     private
 
@@ -138,9 +138,9 @@ begin
       if ENV["DATABASE_URL"]
         [ENV["DATABASE_URL"]]
       else
-        %w(.env .env.test).map { |env_file|
+        %w[.env .env.test].map { |env_file|
           env_path = "./#{env_file}"
-          if File.exists?(env_path)
+          if File.exist?(env_path)
             Pliny::Utils.parse_env(env_path)["DATABASE_URL"]
           else
             nil
@@ -153,7 +153,6 @@ begin
       URI.parse(uri).path[1..-1]
     end
   end
-
 rescue LoadError
   puts "Couldn't load sequel. Skipping database tasks"
 end

--- a/spec/commands/creator_spec.rb
+++ b/spec/commands/creator_spec.rb
@@ -1,5 +1,5 @@
-require 'pliny/commands/creator'
-require 'spec_helper'
+require "pliny/commands/creator"
+require "spec_helper"
 
 describe Pliny::Commands::Creator do
   before do
@@ -7,21 +7,23 @@ describe Pliny::Commands::Creator do
   end
 
   describe "#run!" do
-    before do
-      FileUtils.rm_rf("/tmp/plinytest")
-      FileUtils.mkdir_p("/tmp/plinytest")
-      Dir.chdir("/tmp/plinytest")
+    around do |example|
+      Dir.mktmpdir("plinytest-") do |dir|
+        Dir.chdir(dir) do
+          example.run
+        end
+      end
     end
 
     it "copies the template app over" do
       @gen.run!
-      assert File.exists?("./foobar")
-      assert File.exists?("./foobar/Gemfile")
+      assert File.exist?("./foobar")
+      assert File.exist?("./foobar/Gemfile")
     end
 
     it "deletes the .git from it" do
       @gen.run!
-      refute File.exists?("./foobar/.git")
+      refute File.exist?("./foobar/.git")
     end
 
     it "deletes the .erb files from it" do
@@ -31,25 +33,25 @@ describe Pliny::Commands::Creator do
 
     it "changes DATABASE_URL in .env.sample to use the app name" do
       @gen.run!
-      db_url = File.read("./foobar/.env.sample").split("\n").detect do |line|
+      db_url = File.read("./foobar/.env.sample").split("\n").detect { |line|
         line.include?("DATABASE_URL=")
-      end
+      }
       assert_equal "DATABASE_URL=postgres:///foobar-development", db_url
     end
 
     it "changes DATABASE_URL in .env.test to use the app name" do
       @gen.run!
-      db_url = File.read("./foobar/.env.test").split("\n").detect do |line|
+      db_url = File.read("./foobar/.env.test").split("\n").detect { |line|
         line.include?("DATABASE_URL=")
-      end
+      }
       assert_equal "DATABASE_URL=postgres:///foobar-test", db_url
     end
 
     it "changes APP_NAME in app.json to use the app name" do
       @gen.run!
-      db_url = File.read("./foobar/app.json").split("\n").detect do |line|
+      db_url = File.read("./foobar/app.json").split("\n").detect { |line|
         line.include?("\"name\":")
-      end
+      }
       assert_equal "  \"name\": \"foobar\",", db_url
     end
   end

--- a/spec/commands/updater_spec.rb
+++ b/spec/commands/updater_spec.rb
@@ -1,5 +1,5 @@
-require 'pliny/commands/updater'
-require 'spec_helper'
+require "pliny/commands/updater"
+require "spec_helper"
 
 describe Pliny::Commands::Updater do
   before do
@@ -10,19 +10,21 @@ describe Pliny::Commands::Updater do
   end
 
   describe "#run!" do
-    before do
-      FileUtils.rm_rf("/tmp/plinytest")
-      FileUtils.mkdir_p("/tmp/plinytest")
-      Dir.chdir("/tmp/plinytest")
-      File.open("/tmp/plinytest/Gemfile.lock", "w") do |f|
-        f.puts "    pliny (0.6.3)"
+    around do |example|
+      Dir.mktmpdir("plinytest-") do |dir|
+        Dir.chdir(dir) do
+          File.open("./Gemfile.lock", "w") do |f|
+            f.puts "    pliny (0.6.3)"
+          end
+          example.run
+        end
       end
     end
 
     it "creates a patch with Pliny diffs between the two versions" do
       @cmd.run!
       patch = File.read(@cmd.patch_file)
-      assert patch.include?('--- a/Gemfile')
+      assert patch.include?("--- a/Gemfile")
       assert patch.include?('-gem "pliny", "~> 0.6"')
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -2,14 +2,19 @@ require "spec_helper"
 
 describe "Pliny integration test" do
   before(:all) do
-    FileUtils.rm_rf("/tmp/plinytest")
-    FileUtils.mkdir_p("/tmp/plinytest")
-    Dir.chdir("/tmp/plinytest")
+    @original_dir = Dir.pwd
+
+    test_dir = Dir.mktmpdir("plinytest-")
+    Dir.chdir(test_dir)
 
     bash "pliny-new myapp"
 
-    Dir.chdir("/tmp/plinytest/myapp")
+    Dir.chdir("myapp")
     bash "bin/setup"
+  end
+
+  after(:all) do
+    Dir.chdir(@original_dir)
   end
 
   describe "bin/setup" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -19,7 +19,7 @@ describe "Pliny integration test" do
 
   describe "bin/setup" do
     it "generates .env" do
-      assert File.exists?("./.env")
+      assert File.exist?("./.env")
     end
   end
 
@@ -29,19 +29,19 @@ describe "Pliny integration test" do
     end
 
     it "creates the model file" do
-      assert File.exists?("./lib/models/artist.rb")
+      assert File.exist?("./lib/models/artist.rb")
     end
 
     it "creates the endpoint file" do
-      assert File.exists?("./lib/endpoints/artists.rb")
+      assert File.exist?("./lib/endpoints/artists.rb")
     end
 
     it "creates the serializer file" do
-      assert File.exists?("./lib/serializers/artist.rb")
+      assert File.exist?("./lib/serializers/artist.rb")
     end
 
     it "creates the schema file" do
-      assert File.exists?("./schema/schemata/artist.yaml")
+      assert File.exist?("./schema/schemata/artist.yaml")
     end
   end
 


### PR DESCRIPTION
While investigating an issue with the updater command I noticed a few things:

1. We were hand-rolling a bunch of temp files to hard-coded locations, and then leaving them around.
1. There were some Ruby warnings due to using deprecated methods
1. Inconsistency in how we delimit strings
1. Some other inconsistencies and such (as reported to me via Vim-Ale while I was fixing the above)

This PR cleans all of that up.