### PR TITLE
Ensure all strings with spaces are quoted in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Changed
+  - Ensure all strings with spaces are quoted in logs. ([#332](https://github.com/interagent/pliny/pull/332))
   - Allow ActiveSupport 5 or 6. ([#331](https://github.com/interagent/pliny/pull/331))
 
 ### Fixed

--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -124,7 +124,6 @@ module Pliny
     end
 
     def quote_string(k, v)
-      # try to find a quote style that fits
       if !v.include?('"')
         %{#{k}="#{v}"}
       elsif !v.include?("'")
@@ -140,7 +139,7 @@ module Pliny
 
     def unparse_pair(k, v)
       v = v.call if v.is_a?(Proc)
-      # only quote strings if they include whitespace
+
       if v == nil
         nil
       elsif v == true

--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -146,12 +146,15 @@ module Pliny
         k
       elsif v.is_a?(Float)
         "#{k}=#{format("%.3f", v)}"
-      elsif v.is_a?(String) && v =~ /\s/
-        quote_string(k, v)
       elsif v.is_a?(Time)
         "#{k}=#{v.iso8601}"
       else
-        "#{k}=#{v}"
+        v = "#{v}"
+        if v =~ /\s/
+          quote_string(k, v)
+        else
+          "#{k}=#{v}"
+        end
       end
     end
   end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -5,7 +5,6 @@ describe Pliny::Log do
     @io = StringIO.new
     Pliny.stdout = @io
     Pliny.stderr = @io
-    allow(@io).to receive(:print)
   end
 
   after do

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -176,5 +176,19 @@ describe Pliny::Log do
       end
       Pliny.log(foo: klass.new)
     end
+
+    it "quotes strings that are generated from object interpolation" do
+      expect(@io).to receive(:print).with("foo=\"message with space\"\n")
+      expect(@io).to receive(:print).with("foo=\"bar with space\"\n")
+
+      Pliny.log(foo: StandardError.new("message with space"))
+
+      klass = Class.new do
+        def to_s
+          "bar with space"
+        end
+      end
+      Pliny.log(foo: klass.new)
+    end
   end
 end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -129,4 +129,52 @@ describe Pliny::Log do
       end
     end
   end
+
+  describe "unparsing" do
+    it "removes nils from log" do
+      expect(@io).to receive(:print).with("\n")
+
+      Pliny.log(foo: nil)
+    end
+
+    it "leaves bare keys for true values" do
+      expect(@io).to receive(:print).with("foo\n")
+
+      Pliny.log(foo: true)
+    end
+
+    it "truncates floats" do
+      expect(@io).to receive(:print).with("foo=3.142\n")
+
+      Pliny.log(foo: Math::PI)
+    end
+
+    it "outputs times in ISO8601 format" do
+      expect(@io).to receive(:print).with("foo=2020-01-01T00:00:00Z\n")
+
+      Pliny.log(foo: Time.utc(2020))
+    end
+
+    it "quotes strings that contain spaces" do
+      expect(@io).to receive(:print).with("foo=\"string with spaces\"\n")
+
+      Pliny.log(foo: "string with spaces")
+    end
+
+    it "by default interpolates objects into strings" do
+      expect(@io).to receive(:print).with("foo=message\n")
+      expect(@io).to receive(:print).with("foo=42\n")
+      expect(@io).to receive(:print).with("foo=bar\n")
+
+      Pliny.log(foo: StandardError.new("message"))
+      Pliny.log(foo: 42)
+
+      klass = Class.new do
+        def to_s
+          "bar"
+        end
+      end
+      Pliny.log(foo: klass.new)
+    end
+  end
 end


### PR DESCRIPTION
The current logic covers the case when the log data is already a `String` instance, but not when the data is some other object that, when interpolated into the log string, results in a string containing spaces.

The example that led me here is where an exception is logged and the exception's message contains spaces. The exception gets interpolated into the string and has `to_s` called on it. [`Exception#to_s`](https://ruby-doc.org/core-2.6.5/Exception.html#method-i-to_s) returns the message, so the message (with its spaces) go into the log line, but it's bypassed the logic that adds quotes.

See the commits for more details. I slipped in a few cleanups and added some tests too.