### PR TITLE
Replace newlines in log strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Changed
+  - Ensure newline characters are removed from log strings. ([]())
   - Ensure all strings with spaces are quoted in logs. ([#332](https://github.com/interagent/pliny/pull/332))
   - Allow ActiveSupport 5 or 6. ([#331](https://github.com/interagent/pliny/pull/331))
 

--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -123,13 +123,13 @@ module Pliny
       end
     end
 
-    def quote_string(k, v)
+    def quote_string(v)
       if !v.include?('"')
-        %{#{k}="#{v}"}
+        %{"#{v}"}
       elsif !v.include?("'")
-        %{#{k}='#{v}'}
+        %{'#{v}'}
       else
-        %{#{k}="#{v.gsub(/"/, '\\"')}"}
+        %{"#{v.gsub(/"/, '\\"')}"}
       end
     end
 
@@ -150,11 +150,9 @@ module Pliny
         "#{k}=#{v.iso8601}"
       else
         v = "#{v}"
-        if v =~ /\s/
-          quote_string(k, v)
-        else
-          "#{k}=#{v}"
-        end
+        v = quote_string(v) if v =~ /\s/
+
+        "#{k}=#{v}"
       end
     end
   end

--- a/lib/pliny/log.rb
+++ b/lib/pliny/log.rb
@@ -123,6 +123,10 @@ module Pliny
       end
     end
 
+    def replace_newlines(v)
+      v.gsub("\n", "\\n")
+    end
+
     def quote_string(v)
       if !v.include?('"')
         %{"#{v}"}
@@ -150,6 +154,7 @@ module Pliny
         "#{k}=#{v.iso8601}"
       else
         v = "#{v}"
+        v = replace_newlines(v)
         v = quote_string(v) if v =~ /\s/
 
         "#{k}=#{v}"

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -161,6 +161,12 @@ describe Pliny::Log do
       Pliny.log(foo: "string with spaces")
     end
 
+    it "replaces newlines in strings" do
+      expect(@io).to receive(:print).with("foo=\"string\\nwith newlines\\n\"\n")
+
+      Pliny.log(foo: "string\nwith newlines\n")
+    end
+
     it "by default interpolates objects into strings" do
       expect(@io).to receive(:print).with("foo=message\n")
       expect(@io).to receive(:print).with("foo=42\n")


### PR DESCRIPTION
Pliny logging follows the ["logfmt" pattern](https://brandur.org/logfmt). logfmt is unclear on what should happen with newline characters, but given it's line-based it doesn't seem to make sense to include them in the body of the log line. I couldn't decide between removing, replacing with a space character, or escaping. In the end I went with escaping since it makes it clear to a viewer that a newline _was_ there.

This includes a small refactor - see the commits for details.