### PR TITLE
Fix/update changelog to keep it in sync with "Keep a Changelog" format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
 ## [0.28.0] - 2020-05-06
 ### Changed
   - Ensure all strings with spaces are quoted in logs. ([#332](https://github.com/interagent/pliny/pull/332))
@@ -167,7 +169,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Useless code coverage reports. ([#255](https://github.com/interagent/pliny/pull/255))
 - Cleanup of active database connections after migration runs. ([#257](https://github.com/interagent/pliny/pull/257))
 
-[Unreleased]: https://github.com/interagent/pliny/compare/v0.27.1...HEAD
+[Unreleased]: https://github.com/interagent/pliny/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/interagent/pliny/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/interagent/pliny/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/interagent/pliny/compare/v0.26.2...v0.27.0
 [0.26.2]: https://github.com/interagent/pliny/compare/v0.26.1...v0.26.2


### PR DESCRIPTION
As mentioned at the top of the changelog, it follows [Keep a Changelog](http://keepachangelog.com/). This seems to include an `[Unreleased]` section even if there's nothing unreleased.

Also ensures the github releases are links.

It would be cool if there was a way to check this in CI.