### PR TITLE
Support for Sinatra 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,15 @@ dist: xenial
 services:
   - postgresql
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4
 env:
-  - ACTIVESUPPORT_MAJOR=5 SINATRA_MAJOR=1
   - ACTIVESUPPORT_MAJOR=5 SINATRA_MAJOR=2
-  - ACTIVESUPPORT_MAJOR=6 SINATRA_MAJOR=1
   - ACTIVESUPPORT_MAJOR=6 SINATRA_MAJOR=2
 jobs:
   exclude:
-    - rvm: 2.4
-      env: ACTIVESUPPORT_MAJOR=6 SINATRA_MAJOR=1 # ActiveSupport 6 requries Ruby >= 2.5.0
     - rvm: 2.4
       env: ACTIVESUPPORT_MAJOR=6 SINATRA_MAJOR=2
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 services:
   - postgresql
 rvm:
-  - 2.7
   - 2.6
   - 2.5
   - 2.4

--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -1,6 +1,6 @@
 module Pliny::Helpers
   module Serialize
-    def self.included(base)
+    def self.prepended(base)
       base.send :extend, ClassMethods
     end
 

--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "prmd",           "~> 0.11", ">= 0.11.4"
 
 
-  gem.add_dependency "sinatra",        ">= 1.4", "< 3.0"
+  gem.add_dependency "sinatra",        ">= 2.1", "< 3.0"
   gem.add_dependency "http_accept",    "~> 0.1",  ">= 0.1.5"
   gem.add_dependency "sinatra-router", "~> 0.2",  ">= 0.2.4"
   gem.add_dependency "thor",           "~> 0.19", ">= 0.19.1"


### PR DESCRIPTION
Sinatra 2.1 changed how helpers are loaded. They switched from include to prepend https://github.com/sinatra/sinatra/commit/2db247dd33bb29732a8e1d7e3a2172ee9e153efb

Going forward we need to depend on Sinatra 2.1 or higher.