### PR TITLE
Fix sinatra extension registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 .bundle
 .ruby-*
 .tags
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- **BREAKING**: Register `Serialize` sinatra extension correctly. This will require a change in `lib/endpoints/base.rb` - see [here](https://github.com/interagent/pliny/pull/337/files#diff-c7736e8c14f72274bc01c22fe809a6bb). ([#337](https://github.com/interagent/pliny/pull/337))
 
 ## [0.28.0] - 2020-05-06
 ### Changed

--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -1,41 +1,41 @@
 module Pliny::Helpers
   module Serialize
-    def self.included(base)
-      base.send :extend, ClassMethods
+    def self.registered(base)
+      base.helpers Helpers
       base.set :serializer_class, nil
     end
 
-    def serialize(data, structure = :default)
-      serializer_class = settings.serializer_class
+    module Helpers
+      def serialize(data, structure = :default)
+        serializer_class = settings.serializer_class
 
-      if serializer_class.nil?
-        raise <<~eos.strip
-          No serializer has been specified for this endpoint. Please specify one with
-          `serializer Serializers::ModelName` in the endpoint.
-        eos
-      end
+        if serializer_class.nil?
+          raise <<~eos.strip
+            No serializer has been specified for this endpoint. Please specify one with
+            `serializer Serializers::ModelName` in the endpoint.
+          eos
+        end
 
-      env['pliny.serializer_arity'] = data.respond_to?(:size) ? data.size : 1
+        env['pliny.serializer_arity'] = data.respond_to?(:size) ? data.size : 1
 
-      start = Time.now
-      serializer_class.new(structure).serialize(data).tap do
-        env['pliny.serializer_timing'] = (Time.now - start).to_f
+        start = Time.now
+        serializer_class.new(structure).serialize(data).tap do
+          env['pliny.serializer_timing'] = (Time.now - start).to_f
+        end
       end
     end
 
-    module ClassMethods
-      # Provide a way to specify endpoint serializer class.
-      #
-      # class Endpoints::User < Base
-      #   serializer Serializers::User
-      #
-      #   get do
-      #     encode serialize(User.all)
-      #   end
-      # end
-      def serializer(serializer_class)
-        set :serializer_class, serializer_class
-      end
+    # Provide a way to specify endpoint serializer class.
+    #
+    # class Endpoints::User < Base
+    #   serializer Serializers::User
+    #
+    #   get do
+    #     encode serialize(User.all)
+    #   end
+    # end
+    def serializer(serializer_class)
+      set :serializer_class, serializer_class
     end
   end
 end

--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -8,9 +8,9 @@ module Pliny::Helpers
       serializer_class = self.class.serializer_class
 
       if serializer_class.nil?
-        raise <<-eos.strip
-No serializer has been specified for this endpoint. Please specify one with
-`serializer Serializers::ModelName` in the endpoint.
+        raise <<~eos.strip
+          No serializer has been specified for this endpoint. Please specify one with
+          `serializer Serializers::ModelName` in the endpoint.
         eos
       end
 

--- a/lib/pliny/helpers/serialize.rb
+++ b/lib/pliny/helpers/serialize.rb
@@ -2,10 +2,11 @@ module Pliny::Helpers
   module Serialize
     def self.included(base)
       base.send :extend, ClassMethods
+      base.set :serializer_class, nil
     end
 
     def serialize(data, structure = :default)
-      serializer_class = self.class.serializer_class
+      serializer_class = settings.serializer_class
 
       if serializer_class.nil?
         raise <<~eos.strip
@@ -33,10 +34,8 @@ module Pliny::Helpers
       #   end
       # end
       def serializer(serializer_class)
-        @serializer_class = serializer_class
+        set :serializer_class, serializer_class
       end
-
-      attr_reader :serializer_class
     end
   end
 end

--- a/lib/template/lib/endpoints/base.rb
+++ b/lib/template/lib/endpoints/base.rb
@@ -5,7 +5,7 @@ module Endpoints
 
     helpers Pliny::Helpers::Encode
     helpers Pliny::Helpers::Params
-    helpers Pliny::Helpers::Serialize
+    register Pliny::Helpers::Serialize
 
     set :dump_errors, false
     set :raise_errors, true

--- a/spec/helpers/serialize_spec.rb
+++ b/spec/helpers/serialize_spec.rb
@@ -4,7 +4,7 @@ describe Pliny::Helpers::Serialize do
   context "without a serializer" do
     def app
       Sinatra.new do
-        helpers Pliny::Helpers::Serialize
+        register Pliny::Helpers::Serialize
 
         get "/" do
           MultiJson.encode(serialize([]))
@@ -29,7 +29,7 @@ describe Pliny::Helpers::Serialize do
 
     def app
       Sinatra.new do
-        helpers Pliny::Helpers::Serialize
+        register Pliny::Helpers::Serialize
 
         serializer Serializer
 


### PR DESCRIPTION
It seems like pliny is not configuring its `Serialize` extension correctly. The [extensions guide](http://sinatrarb.com/extensions.html) explains how to extend the DSL (as `Serialize` is doing here with its `serializer` method) - using `register`.

As is stands this module is depending on internal behaviour of sinatra - that it uses `include` to pull in helpers - so it was always at risk of breaking. In sinatra 2.1 it finally broke - [the internal behaviour changed to use `prepend`](https://github.com/sinatra/sinatra/commit/2db247dd33bb29732a8e1d7e3a2172ee9e153efb).

#336 is a simple fix for this - switching the module to assume it is `prepended` rather than `included` - but there is no guarantee this behaviour won't change and break things again. Unfortunately the problem with _this_ change is it requires a change in applications using pliny:

```diff
- helpers Pliny::Helpers::Serialize
+ register Pliny::Helpers::Serialize
```

I would probably just take the hit and go with this change, so we're protected from changes in future. Given pliny is still on a `0.x.y` version it's "allowed" (according to SemVer) to break stuff. I doubt the number of applications using pliny is large, so we're not generating a large amount of effort downstream because of this.