### PR TITLE
Return 400s on unparseable JSON POST payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+  - Return Bad Request (400) instead of Internal Server Error (500) when the JSON request payload is unable to be parsed
+
 ## [0.29.0] - 2020-09-30
 ### Fixed
 - **BREAKING**: Register `Serialize` sinatra extension correctly. This will require a change in `lib/endpoints/base.rb` - see [here](https://github.com/interagent/pliny/pull/337/files#diff-c7736e8c14f72274bc01c22fe809a6bb). ([#337](https://github.com/interagent/pliny/pull/337))

--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -8,9 +8,13 @@ module Pliny::Helpers
 
     def parse_body_params
       if request.media_type == "application/json"
-        p = load_params(MultiJson.decode(request.body.read))
+        begin
+          decoded = MultiJson.decode(request.body.read)
+        rescue MultiJson::ParseError => e
+          raise Pliny::Errors::BadRequest, e.message
+        end
         request.body.rewind
-        p
+        load_params(decoded)
       elsif request.form_data?
         load_params(request.POST)
       else

--- a/spec/helpers/params_spec.rb
+++ b/spec/helpers/params_spec.rb
@@ -34,4 +34,12 @@ describe Pliny::Helpers::Params do
     post "/", "<hello>world</hello>", {"CONTENT_TYPE" => "application/xml"}
     assert_equal "{}", last_response.body
   end
+
+  it "should throw bad request when receiving invalid json via post" do
+    err = assert_raises(Pliny::Errors::BadRequest) do
+      post "/", "{\"foo\"}", {"CONTENT_TYPE" => "application/json"}
+    end
+
+    assert_match /unexpected token/, err.message
+  end
 end


### PR DESCRIPTION
When someone tries to parse bad request JSON, pliny right now will by default return a 500 via the web with an exception such as this logged:

```
MultiJson::ParseError: unexpected character (after foo.bar) at line 1, column 14 [parse.c:724]
```

Invalid JSON post bodies should instead return a 400, and the parse error somewhere in the body.

This PR wraps around the place we parse JSON and returns the appropriate pliny exception with a more helpful message attached to the response.