### PR TITLE
GitHub actions ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Gem version](http://img.shields.io/gem/v/pliny.svg)](https://rubygems.org/gems/pliny)
 [![Build Status](https://travis-ci.org/interagent/pliny.svg?branch=master)](https://travis-ci.org/interagent/pliny)
+[![Github Actions CI](https://github.com/interagent/pliny/actions/workflows/CI/badge.svg)](https://github.com/interagent/pliny/actions)
+
 
 Pliny helps Ruby developers write and maintain excellent APIs.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pliny
 
 [![Gem version](http://img.shields.io/gem/v/pliny.svg)](https://rubygems.org/gems/pliny)
-[![Build Status](https://travis-ci.org/interagent/pliny.svg?branch=master)](https://travis-ci.org/interagent/pliny)
 [![Github Actions CI](https://github.com/interagent/pliny/actions/workflows/ruby.yml/badge.svg)](https://github.com/interagent/pliny/actions)
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem version](http://img.shields.io/gem/v/pliny.svg)](https://rubygems.org/gems/pliny)
 [![Build Status](https://travis-ci.org/interagent/pliny.svg?branch=master)](https://travis-ci.org/interagent/pliny)
-[![Github Actions CI](https://github.com/interagent/pliny/actions/workflows/CI/badge.svg)](https://github.com/interagent/pliny/actions)
+[![Github Actions CI](https://github.com/interagent/pliny/actions/workflows/ruby.yml/badge.svg)](https://github.com/interagent/pliny/actions)
 
 
 Pliny helps Ruby developers write and maintain excellent APIs.


### PR DESCRIPTION
## Description

This PR fixes the CI status badge.

## Testing

1. visit https://github.com/interagent/pliny/blob/github-actions-ci-badge/README.md
2. notice the badge
3. rejoice
