### PR TITLE
Fix pg_dump call

### DIFF
--- a/lib/pliny/tasks/db.rake
+++ b/lib/pliny/tasks/db.rake
@@ -6,6 +6,7 @@ begin
   require "sequel"
   require "sequel/extensions/migration"
   require "pliny/db_support"
+  require "shellwords"
 
   namespace :db do
     desc "Get current schema version"
@@ -109,7 +110,11 @@ begin
       task :dump do
         file = File.join("db", "schema.sql")
         database_url = database_urls.first
-        `pg_dump -s -x -O -f #{file} #{database_url}`
+        `pg_dump -s -x -O -f #{file.shellescape} #{database_url.shellescape}`
+        if $?.exitstatus != 0
+          puts "Failed to dump schema"
+          exit 1
+        end
 
         schema = File.read(file)
         # filter all COMMENT ON EXTENSION, only owners and the db


### PR DESCRIPTION
The pg_dump call takes database url and the file name as arguments but it doesn't escape them. When the file name contains &, it causes a failure on the connection. Also, the dump should fail fast when the pg_dump call is not successful.