### PR TITLE
fix: handle args correctly in ruby 3.1.2

### DIFF
--- a/lib/pliny/metrics.rb
+++ b/lib/pliny/metrics.rb
@@ -16,10 +16,12 @@ module Pliny
       counts
     end
 
-    def measure(*names, **opts, &block)
+    def measure(*inputs, &block)
       if block
         elapsed, return_value = time_elapsed(&block)
       end
+
+      opts = inputs.last.is_a?(Hash) ? inputs.pop : {}
 
       measurement =
         if opts.has_key?(:value)
@@ -30,7 +32,7 @@ module Pliny
           0
         end
 
-      measures = Hash[names.map { |n| ["#{Config.app_name}.#{n}", measurement] }]
+      measures = Hash[inputs.map { |n| ["#{Config.app_name}.#{n}", measurement] }]
 
       backends.each do |backend|
         report_and_catch { backend.report_measures(measures) }

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -102,5 +102,21 @@ describe Pliny::Metrics do
         "pliny.waldo" => 0
       )
     end
+
+    it "measures value in implicit hash with multiple metrics names" do
+      metrics.measure("metric.name", "another.name", value: 3.14, foo: :bar)
+      expect(test_backend).to have_received(:report_measures).once.with(
+        "pliny.metric.name" => 3.14,
+        "pliny.another.name" => 3.14
+      )
+    end
+
+    it "measures value in explicit hash with multiple metrics names" do
+      metrics.measure("metric.name", "another.name", { value: 3.14, foo: :bar })
+      expect(test_backend).to have_received(:report_measures).once.with(
+        "pliny.metric.name" => 3.14,
+        "pliny.another.name" => 3.14
+      )
+    end
   end
 end


### PR DESCRIPTION
While upgrading a pliny app to 3.1.2, we saw invalid argument errors when trying to use the metrics. This was due to the fact that the in ruby 3, the `*names` grabs the `**options`. This difference causes a metric explosion as hashes with values are sent in as their own metric.

This ruby code shows the issue if you run this in 2.7.4 and 3.1.2:

```ruby
def foo(*names, **opts, &block)
  puts "names: #{names.inspect}"
  puts "opts: #{opts.inspect}"
  puts "block: #{block}"
end

foo("foo", {bar: :baz}) do
  puts "block"
end
```