### PR TITLE
add support for Sinatra 4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2']
         activesupport-version: ['6', '7']
-        sinatra-version: ['2', '3']
+        sinatra-version: ['2', '3', '4']
     env:
       ACTIVESUPPORT_MAJOR: ${{ matrix.activesupport-version }}
       SINATRA_MAJOR: ${{ matrix.sinatra-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - 🔜
+### Added
+- Add support for Sinatra 4 ([#361](https://github.com/interagent/pliny/pull/361))
+
 ### Changed
 - Switched branch from master to main ([#362](https://github.com/interagent/pliny/pull/362))
 

--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -4,7 +4,7 @@ module Pliny
       attr_accessor :id
 
       def self.render(error)
-        headers = { "Content-Type" => "application/json; charset=utf-8" }
+        headers = { "content-type" => "application/json; charset=utf-8" }
         data = { id: error.id, message: error.message }
         [error.status, headers, [MultiJson.encode(data)]]
       end

--- a/lib/pliny/middleware/cors.rb
+++ b/lib/pliny/middleware/cors.rb
@@ -44,12 +44,12 @@ module Pliny::Middleware
 
     def cors_headers(env)
       {
-        'Access-Control-Allow-Origin'      => env["HTTP_ORIGIN"],
-        'Access-Control-Allow-Methods'     => ALLOW_METHODS.join(', '),
-        'Access-Control-Allow-Headers'     => allow_headers.join(', '),
-        'Access-Control-Allow-Credentials' => "true",
-        'Access-Control-Max-Age'           => "1728000",
-        'Access-Control-Expose-Headers'    => EXPOSE_HEADERS.join(', ')
+        'access-control-allow-origin'      => env["HTTP_ORIGIN"],
+        'access-control-allow-methods'     => ALLOW_METHODS.join(', '),
+        'access-control-allow-headers'     => allow_headers.join(', '),
+        'access-control-allow-credentials' => "true",
+        'access-control-max-age'           => "1728000",
+        'access-control-expose-headers'    => EXPOSE_HEADERS.join(', ')
       }
     end
   end

--- a/lib/pliny/middleware/versioning.rb
+++ b/lib/pliny/middleware/versioning.rb
@@ -26,7 +26,7 @@ module Pliny::Middleware
             error = { id: :bad_version, message: <<-eos }
 Please specify a version along with the MIME type. For example, `Accept: application/vnd.#{@app_name}+json; version=1`.
             eos
-            return [400, { "Content-Type" => "application/json; charset=utf-8" },
+            return [400, { "content-type" => "application/json; charset=utf-8" },
               [MultiJson.encode(error)]]
           end
 

--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -20,15 +20,15 @@ Gem::Specification.new do |gem|
   gem.add_dependency "prmd",           "~> 0.11", ">= 0.11.4"
 
 
-  gem.add_dependency "sinatra",        ">= 2.0", "< 4.0"
+  gem.add_dependency "sinatra",        ">= 2.0", "< 5.0"
   gem.add_dependency "http_accept",    "~> 0.1",  ">= 0.1.5"
   gem.add_dependency "sinatra-router", "~> 0.2",  ">= 0.2.4"
   gem.add_dependency "thor",           ">= 0.19", "< 2.0"
 
   gem.add_development_dependency "rake",              "~> 13.0"
-  gem.add_development_dependency "rack-test",         "~> 1.1.0"
+  gem.add_development_dependency "rack-test",         "~> 2"
   gem.add_development_dependency "rspec",             "~> 3.1", ">= 3.1.0"
-  gem.add_development_dependency "sinatra-contrib",   ">= 2.0", "< 4.0"
+  gem.add_development_dependency "sinatra-contrib",   ">= 2.0", "< 5.0"
   gem.add_development_dependency "timecop", "~> 0.7", ">= 0.7.1"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-byebug"


### PR DESCRIPTION
What?
add support for Sinatra 4

Why the header changes?
newer rack version ship with a linter and according to the rack spec, headers have to be lower case. 