### PR TITLE
use JSON instead of MultiJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add support for Ruby 3.3 and 3.4 ([#366](https://github.com/interagent/pliny/pull/3366))
 - Add support for ActiveSupport 8 ([#366](https://github.com/interagent/pliny/pull/366))
 
+### Changed
+- use built-in JSON module instead of MultiJson ([#367](https://github.com/interagent/pliny/pull/367))
+
 ### Removed
 - Drop support for Ruby 3.0 and 3.1 ([#366](https://github.com/interagent/pliny/pull/366))
 - Drop support for Sinatra 2 ([#366](https://github.com/interagent/pliny/pull/366))

--- a/lib/pliny.rb
+++ b/lib/pliny.rb
@@ -1,4 +1,4 @@
-require "multi_json"
+require "json"
 require "sinatra/base"
 
 require_relative "pliny/version"

--- a/lib/pliny/errors.rb
+++ b/lib/pliny/errors.rb
@@ -6,7 +6,7 @@ module Pliny
       def self.render(error)
         headers = { "content-type" => "application/json; charset=utf-8" }
         data = { id: error.id, message: error.message }
-        [error.status, headers, [MultiJson.encode(data)]]
+        [error.status, headers, [JSON.generate(data)]]
       end
 
       def initialize(message, id)

--- a/lib/pliny/helpers/encode.rb
+++ b/lib/pliny/helpers/encode.rb
@@ -2,7 +2,11 @@ module Pliny::Helpers
   module Encode
     def encode(object)
       content_type :json, charset: 'utf-8'
-      MultiJson.encode(object, pretty: params[:pretty] == 'true' || Config.pretty_json)
+      if params[:pretty] == 'true' || Config.pretty_json
+        JSON.pretty_generate(object)
+      else
+        JSON.generate(object)
+      end
     end
   end
 end

--- a/lib/pliny/helpers/params.rb
+++ b/lib/pliny/helpers/params.rb
@@ -9,8 +9,8 @@ module Pliny::Helpers
     def parse_body_params
       if request.media_type == "application/json"
         begin
-          decoded = MultiJson.decode(request.body.read)
-        rescue MultiJson::ParseError => e
+          decoded = JSON.parse(request.body.read)
+        rescue JSON::ParserError => e
           raise Pliny::Errors::BadRequest, e.message
         end
         request.body.rewind

--- a/lib/pliny/middleware/versioning.rb
+++ b/lib/pliny/middleware/versioning.rb
@@ -27,7 +27,7 @@ module Pliny::Middleware
 Please specify a version along with the MIME type. For example, `Accept: application/vnd.#{@app_name}+json; version=1`.
             eos
             return [400, { "content-type" => "application/json; charset=utf-8" },
-              [MultiJson.encode(error)]]
+              [JSON.generate(error)]]
           end
 
           unless version

--- a/lib/pliny/templates/endpoint_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_acceptance_test.erb
@@ -23,7 +23,7 @@ RSpec.describe Endpoints::<%= plural_class_name %> do
   describe 'POST <%= url_path %>' do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
-      post '<%= url_path %>', MultiJson.encode({})
+      post '<%= url_path %>', JSON.generate({})
       assert_equal 201, last_response.status
       assert_schema_conform
     end
@@ -40,7 +40,7 @@ RSpec.describe Endpoints::<%= plural_class_name %> do
   describe 'PATCH <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
-      patch '<%= url_path %>/123', MultiJson.encode({})
+      patch '<%= url_path %>/123', JSON.generate({})
       assert_equal 200, last_response.status
       assert_schema_conform
     end

--- a/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
+++ b/lib/pliny/templates/endpoint_scaffold_acceptance_test.erb
@@ -32,7 +32,7 @@ RSpec.describe Endpoints::<%= plural_class_name %> do
   describe 'POST <%= url_path %>' do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
-      post '<%= url_path %>', MultiJson.encode({})
+      post '<%= url_path %>', JSON.generate({})
       assert_equal 201, last_response.status
       assert_schema_conform
     end
@@ -50,7 +50,7 @@ RSpec.describe Endpoints::<%= plural_class_name %> do
   describe 'PATCH <%= url_path %>/:id' do
     it 'returns correct status code and conforms to schema' do
       header "Content-Type", "application/json"
-      patch "<%= url_path %>/#{@<%= field_name %>.id}", MultiJson.encode({})
+      patch "<%= url_path %>/#{@<%= field_name %>.id}", JSON.generate({})
       assert_equal 200, last_response.status
       assert_schema_conform
     end

--- a/lib/template/Gemfile
+++ b/lib/template/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 ruby "2.4.0"
 
-gem "multi_json"
-gem "oj"
 gem "pg"
 gem "pliny", "~> 0.32"
 gem "pry"

--- a/lib/template/spec/endpoints/health_spec.rb
+++ b/lib/template/spec/endpoints/health_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Endpoints::Health do
       assert_equal(200, last_response.status)
       assert_equal("application/json;charset=utf-8", last_response.headers["Content-Type"])
       assert_equal(2, last_response.headers["Content-Length"].to_i)
-      assert_equal({}, MultiJson.decode(last_response.body))
+      assert_equal({}, JSON.parse(last_response.body))
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Endpoints::Health do
       assert_equal(200, last_response.status)
       assert_equal("application/json;charset=utf-8", last_response.headers["Content-Type"])
       assert_equal(2, last_response.headers["Content-Length"].to_i)
-      assert_equal({}, MultiJson.decode(last_response.body))
+      assert_equal({}, JSON.parse(last_response.body))
     end
   end
 end

--- a/pliny.gemspec
+++ b/pliny.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 3.2"
 
   gem.add_dependency "activesupport",  ">= 7.0", "< 9.0"
-  gem.add_dependency "multi_json",     "~> 1.9",  ">= 1.9.3"
   gem.add_dependency "prmd",           "~> 0.11", ">= 0.11.4"
 
   gem.add_dependency "sinatra",        ">= 2.0", "< 5.0"

--- a/spec/commands/generator/endpoint_spec.rb
+++ b/spec/commands/generator/endpoint_spec.rb
@@ -26,31 +26,31 @@ describe Pliny::Commands::Generator::Endpoint do
     it "defines a stub GET /" do
       get "/artists"
       assert_equal 200, last_response.status
-      assert_equal [], MultiJson.decode(last_response.body)
+      assert_equal [], JSON.parse(last_response.body)
     end
 
     it "defines a stub POST /" do
       post "/artists"
       assert_equal 201, last_response.status
-      assert_equal Hash.new, MultiJson.decode(last_response.body)
+      assert_equal Hash.new, JSON.parse(last_response.body)
     end
 
     it "defines a stub GET /:id" do
       get "/artists/123"
       assert_equal 200, last_response.status
-      assert_equal Hash.new, MultiJson.decode(last_response.body)
+      assert_equal Hash.new, JSON.parse(last_response.body)
     end
 
     it "defines a stub PATCH /:id" do
       patch "/artists/123"
       assert_equal 200, last_response.status
-      assert_equal Hash.new, MultiJson.decode(last_response.body)
+      assert_equal Hash.new, JSON.parse(last_response.body)
     end
 
     it "defines a stub DELETE /:id" do
       delete "/artists/123"
       assert_equal 200, last_response.status
-      assert_equal Hash.new, MultiJson.decode(last_response.body)
+      assert_equal Hash.new, JSON.parse(last_response.body)
     end
 
   end

--- a/spec/helpers/encode_spec.rb
+++ b/spec/helpers/encode_spec.rb
@@ -23,19 +23,19 @@ describe Pliny::Helpers::Encode do
   it "encodes as json" do
     payload = { "foo" => "bar" }
     post "/", payload
-    assert_equal MultiJson.encode(payload), last_response.body
+    assert_equal JSON.generate(payload), last_response.body
   end
 
   it "encodes in pretty mode when pretty=true" do
     payload = { "foo" => "bar", "pretty" => "true" }
     post "/", payload
-    assert_equal MultiJson.encode(payload, pretty: true), last_response.body
+    assert_equal JSON.pretty_generate(payload), last_response.body
   end
 
   it "encodes in pretty mode when set by config" do
     allow(Config).to receive(:pretty_json) { true }
     payload = { "foo" => "bar" }
     post "/", payload
-    assert_equal MultiJson.encode(payload, pretty: true), last_response.body
+    assert_equal JSON.pretty_generate(payload), last_response.body
   end
 end

--- a/spec/helpers/serialize_spec.rb
+++ b/spec/helpers/serialize_spec.rb
@@ -7,7 +7,7 @@ describe Pliny::Helpers::Serialize do
         register Pliny::Helpers::Serialize
 
         get "/" do
-          MultiJson.encode(serialize([]))
+          JSON.generate(serialize([]))
         end
       end
     end
@@ -34,11 +34,11 @@ describe Pliny::Helpers::Serialize do
         serializer Serializer
 
         get "/" do
-          MultiJson.encode(serialize([]))
+          JSON.generate(serialize([]))
         end
 
         get "/env" do
-          MultiJson.encode(serialize(env))
+          JSON.generate(serialize(env))
         end
       end
     end
@@ -46,13 +46,13 @@ describe Pliny::Helpers::Serialize do
     it "encodes as json" do
       get "/"
       assert_equal 200, last_response.status
-      assert_equal MultiJson.encode([]), last_response.body
+      assert_equal JSON.generate([]), last_response.body
     end
 
     it "emits information for canonical log lines" do
       get "/env"
       assert_equal 200, last_response.status
-      body = MultiJson.decode(last_response.body)
+      body = JSON.parse(last_response.body)
       assert body["pliny.serializer_arity"] > 1
       assert body["pliny.serializer_timing"] > 0
     end

--- a/spec/middleware/rescue_errors_spec.rb
+++ b/spec/middleware/rescue_errors_spec.rb
@@ -21,7 +21,7 @@ describe Pliny::Middleware::RescueErrors do
     @app = new_rack_app
     get "/api-error"
     assert_equal 503, last_response.status
-    error_json = MultiJson.decode(last_response.body)
+    error_json = JSON.parse(last_response.body)
     assert_equal "service_unavailable", error_json["id"]
     assert_equal "Service unavailable.", error_json["message"]
   end
@@ -31,7 +31,7 @@ describe Pliny::Middleware::RescueErrors do
     expect(Pliny::ErrorReporters).to receive(:notify)
     get "/"
     assert_equal 500, last_response.status
-    error_json = MultiJson.decode(last_response.body)
+    error_json = JSON.parse(last_response.body)
     assert_equal "internal_server_error", error_json["id"]
     assert_equal "Internal server error.", error_json["message"]
   end
@@ -48,7 +48,7 @@ describe Pliny::Middleware::RescueErrors do
     allow(Pliny::ErrorReporters).to receive(:notify)
     get "/"
     assert_equal 500, last_response.status
-    error_json = MultiJson.decode(last_response.body)
+    error_json = JSON.parse(last_response.body)
     assert_equal "internal_server_error", error_json["id"]
     assert_equal "Please stand by", error_json["message"]
   end

--- a/spec/middleware/versioning_spec.rb
+++ b/spec/middleware/versioning_spec.rb
@@ -13,7 +13,7 @@ describe Pliny::Middleware::Versioning do
       use Pliny::Middleware::Versioning, default: '2', app_name: 'pliny'
       run Sinatra.new {
         get "/" do
-          MultiJson.encode env
+          JSON.generate env
         end
       }
     end
@@ -21,7 +21,7 @@ describe Pliny::Middleware::Versioning do
 
   it "produces default version on application/json" do
     get '/', {}, {'HTTP_ACCEPT' => 'application/json'}
-    json = MultiJson.decode(last_response.body)
+    json = JSON.parse(last_response.body)
     assert_equal 'application/json', json['HTTP_ACCEPT']
     assert_equal '2', json['HTTP_X_API_VERSION']
   end
@@ -33,19 +33,19 @@ Please specify a version along with the MIME type. For example, `Accept: applica
     eos
 
     assert_equal 400, last_response.status
-    assert_equal MultiJson.encode(error), last_response.body
+    assert_equal JSON.generate(error), last_response.body
   end
 
   it "ignores a wrong app name" do
     get '/', {}, {'HTTP_ACCEPT' => 'application/vnd.chuck_norris+json'}
-    json = MultiJson.decode(last_response.body)
+    json = JSON.parse(last_response.body)
     assert_equal 'application/vnd.chuck_norris+json', json['HTTP_ACCEPT']
     assert_equal '2', json['HTTP_X_API_VERSION']
   end
 
   it "produces a version on application/vnd.pliny+json; version=3" do
     get '/', {}, {'HTTP_ACCEPT' => 'application/vnd.pliny+json; version=3'}
-    json = MultiJson.decode(last_response.body)
+    json = JSON.parse(last_response.body)
     assert_equal 'application/json', json['HTTP_ACCEPT']
     assert_equal '3', json['HTTP_X_API_VERSION']
   end
@@ -53,14 +53,14 @@ Please specify a version along with the MIME type. For example, `Accept: applica
   # this behavior is pretty sketchy, but a pretty extreme edge case
   it "handles multiple MIME types" do
     get '/', {}, {'HTTP_ACCEPT' => 'application/vnd.pliny+json; version=3; q=0.5, text/xml'}
-    json = MultiJson.decode(last_response.body)
+    json = JSON.parse(last_response.body)
     assert_equal 'text/xml, application/json; q=0.5', json['HTTP_ACCEPT']
     assert_equal '3', json['HTTP_X_API_VERSION']
   end
 
   it "produces the priority version on multiple types" do
     get '/', {}, {'HTTP_ACCEPT' => 'application/vnd.pliny+json; version=4; q=0.5, application/vnd.pliny+json; version=3'}
-    json = MultiJson.decode(last_response.body)
+    json = JSON.parse(last_response.body)
     assert_equal 'application/json, application/json; q=0.5', json['HTTP_ACCEPT']
     assert_equal '3', json['HTTP_X_API_VERSION']
   end


### PR DESCRIPTION
The built-in JSON library is now as fast as `oj` and there is no reason to keep `MultiJson` or `oj` around if we can rely on what Ruby has

https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html
https://byroot.github.io/ruby/json/2024/12/18/optimizing-ruby-json-part-2.html
https://byroot.github.io/ruby/json/2024/12/27/optimizing-ruby-json-part-3.html
https://byroot.github.io/ruby/json/2024/12/29/optimizing-ruby-json-part-4.html
https://byroot.github.io/ruby/json/2025/01/04/optimizing-ruby-json-part-5.html
https://byroot.github.io/ruby/json/2025/01/12/optimizing-ruby-json-part-6.html
https://byroot.github.io/ruby/json/2025/01/14/optimizing-ruby-json-part-7.html