### PR TITLE
Avoid reading global Git configuration

### DIFF
--- a/lib/pliny/commands/updater.rb
+++ b/lib/pliny/commands/updater.rb
@@ -59,7 +59,7 @@ module Pliny::Commands
 
     def save_patch(curr, target)
       # take a diff of changes that happened to the template app in Pliny
-      diff = `cd #{repo_dir} && git diff v#{curr}..v#{target} lib/template/`
+      diff = `cd #{repo_dir} && GIT_CONFIG_GLOBAL=/dev/null git diff v#{curr}..v#{target} lib/template/`
 
       # remove /lib/template from the path of files in the patch so that we can
       # apply these to the current folder


### PR DESCRIPTION
I have a global Git configuration file which sets [`diff.noPrefix`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-diffnoPrefix) to false. This means `git diff` won't produce `a/` and `b/` prefixes for changed paths.

This breaks an assumption in one of the tests:

https://github.com/interagent/pliny/blob/3641a4443114789c73832067221bcc1ed4bb968f/spec/commands/updater_spec.rb#L29

There's a lot of settings that may potentially cause Git to behave differently so I'm using [the `GIT_CONFIG_GLOBAL` environment variable](https://git-scm.com/docs/git#Documentation/git.txt-GITCONFIGGLOBAL) to prevent ever reading the user's configuration.

(I'm not making a note in the changeling as this both seems below the line in terms of importance and shouldn't matter to anyone who isn't contributing to Pliny itself.)
