### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [2.0.0] - 2025-09-29
+
+### Changed
+- Update minimum required version of sinatra from 2 to 3 (https://github.com/interagent/pliny/pull/370)
+- Update templates for new projects to reflect new version requirements (https://github.com/interagent/pliny/pull/370
+- ensure Ruby 3.5 compatibility (https://github.com/interagent/pliny/pull/370)
+- added RuboCop as a linter for pliny itself (https://github.com/interagent/pliny/pull/370)
+- fixed all linting errors from RuboCop (lots of PR's)
 
 ### Changed
 - Gemfile template updated with the latest available dependencies (https://github.com/interagent/pliny/pull/379)
 
 ### Removed
-
 - Remove deprecated `PLINY_ENV` environment variable support in favor of `APP_ENV` to align with Sinatra conventions (https://github.com/interagent/pliny/pull/373)
 
 ## [1.3.0] - 2025-09-29

--- a/lib/pliny/version.rb
+++ b/lib/pliny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pliny
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
In addition to 1.3 (see https://github.com/interagent/pliny/tree/bf/v1.3.0) which only contains a new Sentry error reporter and is compatible to 1.x. This releases 2.0 with the latest changes from `main` which has backwards incompatible changes in addition to the Sentry reporter